### PR TITLE
Add regression test for BindingContext.PropertyType (stacked on #8)

### DIFF
--- a/src/Tests/ExistForAll.SimpleSettings.UnitTests/SimpleSettings/BindingContextTests.cs
+++ b/src/Tests/ExistForAll.SimpleSettings.UnitTests/SimpleSettings/BindingContextTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace ExistForAll.SimpleSettings.UnitTests.SimpleSettings
+{
+	public class BindingContextTests
+	{
+		[Test]
+		public async Task BindPropertySettings_ContextPropertyType_IsThePropertysOwnType()
+		{
+			var binder = new CapturingBinder();
+
+			SettingsBuilder.CreateBuilder(x => x.AddSectionBinder(binder))
+				.GetSettings<ICaptureSettings>();
+
+			// PropertyType must be each property's own type — not the declaring interface
+			// (regression guard: it was previously set to propertyInfo.DeclaringType).
+			await Assert.That(binder.Captured[nameof(ICaptureSettings.Name)].PropertyType).IsEqualTo(typeof(string));
+			await Assert.That(binder.Captured[nameof(ICaptureSettings.Count)].PropertyType).IsEqualTo(typeof(int));
+		}
+
+		[Test]
+		public async Task BindPropertySettings_ContextStillExposesDeclaringInterface()
+		{
+			var binder = new CapturingBinder();
+
+			SettingsBuilder.CreateBuilder(x => x.AddSectionBinder(binder))
+				.GetSettings<ICaptureSettings>();
+
+			var context = binder.Captured[nameof(ICaptureSettings.Name)];
+
+			// Fixing PropertyType did not remove access to the declaring type: the settings
+			// interface is on SettingsType, and the property's declaring type on PropertyInfo.
+			await Assert.That(context.SettingsType).IsEqualTo(typeof(ICaptureSettings));
+			await Assert.That(context.PropertyInfo.DeclaringType).IsEqualTo(typeof(ICaptureSettings));
+		}
+
+		private sealed class CapturingBinder : ISectionBinder
+		{
+			public Dictionary<string, BindingContext> Captured { get; } = new Dictionary<string, BindingContext>();
+
+			public void BindPropertySettings(BindingContext context)
+			{
+				Captured[context.Key] = context;
+			}
+		}
+
+		public interface ICaptureSettings
+		{
+			string Name { get; set; }
+			int Count { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on top of #8. Adds the regression test for the **B4** fix in that PR — `BindingContext.PropertyType` must expose each property's *own* type, not its declaring interface.

> ℹ️ Base is `fix/phase-1-correctness-bugs` (the #8 branch) rather than `master`, because the test depends on the fix. GitHub auto-retargets this PR to `master` once #8 merges.

## Tests added — `Tests/.../SimpleSettings/BindingContextTests.cs`

A custom `ISectionBinder` captures the `BindingContext` handed to it per property.

- **`BindPropertySettings_ContextPropertyType_IsThePropertysOwnType`** — asserts `context.PropertyType` is `string` / `int` (the property types), not the interface. **Fail-first verified**: with the fix reverted to `propertyInfo.DeclaringType`, it reports `ICaptureSettings` instead of `System.String`.
- **`BindPropertySettings_ContextStillExposesDeclaringInterface`** — documents that the fix did **not** remove access to the declaring type: it stays reachable via `context.SettingsType` and `context.PropertyInfo.DeclaringType`.

## Verification

`dotnet test` from `src/` → **92 green** on `net8.0` + `net10.0` (2 new methods × 2 TFMs on top of #8's 88).
