### PR TITLE
Re-land BindingContext.PropertyType regression test on master

### DIFF
--- a/src/Tests/ExistForAll.SimpleSettings.UnitTests/SimpleSettings/BindingContextTests.cs
+++ b/src/Tests/ExistForAll.SimpleSettings.UnitTests/SimpleSettings/BindingContextTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+
+namespace ExistForAll.SimpleSettings.UnitTests.SimpleSettings
+{
+	public class BindingContextTests
+	{
+		[Test]
+		public async Task BindPropertySettings_ContextPropertyType_IsThePropertysOwnType()
+		{
+			var binder = new CapturingBinder();
+
+			SettingsBuilder.CreateBuilder(x => x.AddSectionBinder(binder))
+				.GetSettings<ICaptureSettings>();
+
+			// PropertyType must be each property's own type — not the declaring interface
+			// (regression guard: it was previously set to propertyInfo.DeclaringType).
+			await Assert.That(binder.Captured[nameof(ICaptureSettings.Name)].PropertyType).IsEqualTo(typeof(string));
+			await Assert.That(binder.Captured[nameof(ICaptureSettings.Count)].PropertyType).IsEqualTo(typeof(int));
+		}
+
+		[Test]
+		public async Task BindPropertySettings_ContextStillExposesDeclaringInterface()
+		{
+			var binder = new CapturingBinder();
+
+			SettingsBuilder.CreateBuilder(x => x.AddSectionBinder(binder))
+				.GetSettings<ICaptureSettings>();
+
+			var context = binder.Captured[nameof(ICaptureSettings.Name)];
+
+			// Fixing PropertyType did not remove access to the declaring type: the settings
+			// interface is on SettingsType, and the property's declaring type on PropertyInfo.
+			await Assert.That(context.SettingsType).IsEqualTo(typeof(ICaptureSettings));
+			await Assert.That(context.PropertyInfo.DeclaringType).IsEqualTo(typeof(ICaptureSettings));
+		}
+
+		private sealed class CapturingBinder : ISectionBinder
+		{
+			public Dictionary<string, BindingContext> Captured { get; } = new Dictionary<string, BindingContext>();
+
+			public void BindPropertySettings(BindingContext context)
+			{
+				Captured[context.Key] = context;
+			}
+		}
+
+		public interface ICaptureSettings
+		{
+			string Name { get; set; }
+			int Count { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Re-lands the `BindingContext.PropertyType` regression test onto `master`.

The test was approved in #9, but #9 was stacked on the #8 branch and merged there; since #8 was squash-merged to `master` separately, the test never reached `master`. This cherry-picks it over. The B4 fix it guards is already on `master` (via #8), so the suite is green.

## Test — `Tests/.../SimpleSettings/BindingContextTests.cs`
- `..._IsThePropertysOwnType` — a custom `ISectionBinder` captures the per-property `BindingContext`; asserts `PropertyType` is the property's type (`string`/`int`), not the declaring interface.
- `..._StillExposesDeclaringInterface` — the declaring type stays reachable via `SettingsType` and `PropertyInfo.DeclaringType`.

`dotnet test` from `src/` → **92 green** (net8.0 + net10.0).
