### PR TITLE
Fix ExistsForAll namespace typo in the Binders package

### DIFF
--- a/src/Core/ExistAll.SimpleConfig.Extensions.Binders/CommandLineSettingsBinder.cs
+++ b/src/Core/ExistAll.SimpleConfig.Extensions.Binders/CommandLineSettingsBinder.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using ExistForAll.SimpleSettings;
 using ExistForAll.SimpleSettings.Binders;
 
-namespace ExistsForAll.SimpleSettings.Binders
+namespace ExistForAll.SimpleSettings.Binders
 {
    public class CommandLineSettingsBinder : ISectionBinder
    {

--- a/src/Core/ExistAll.SimpleConfig.Extensions.Binders/ExistForAll.SimpleSettings.Binders.csproj
+++ b/src/Core/ExistAll.SimpleConfig.Extensions.Binders/ExistForAll.SimpleSettings.Binders.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
-    <RootNamespace>ExistsForAll.SimpleSettings.Binders</RootNamespace>
+    <RootNamespace>ExistForAll.SimpleSettings.Binders</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Core/ExistAll.SimpleConfig.Extensions.Binders/SettingsBuilderFactoryExtensions.cs
+++ b/src/Core/ExistAll.SimpleConfig.Extensions.Binders/SettingsBuilderFactoryExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using ExistsForAll.SimpleSettings.Binders;
 using Microsoft.Extensions.Configuration;
 
 namespace ExistForAll.SimpleSettings.Binders


### PR DESCRIPTION
## Summary

Fixes the `ExistsForAll` → `ExistForAll` namespace typo in the **Binders** package.

`CommandLineSettingsBinder` was declared in `ExistsForAll.SimpleSettings.Binders` (extra "s"), while every other type in the package — `ConfigurationBinder`, `EnvironmentVariableBinder`, the options types, `SettingsBuilderFactoryExtensions` — lives in `ExistForAll.SimpleSettings.Binders`. Consumers had to import two nearly-identical namespaces to use one package.

## Changes
- `CommandLineSettingsBinder` namespace → `ExistForAll.SimpleSettings.Binders`
- `<RootNamespace>` in the project file → `ExistForAll.SimpleSettings.Binders`
- Dropped the now-redundant `using ExistsForAll.SimpleSettings.Binders;` in `SettingsBuilderFactoryExtensions`

## Notes
- **Breaking** (public namespace change) — done intentionally while pre-2.0.0-stable (no stable `v*` tag yet).
- Build + `dotnet test` green on net8.0 + net10.0.

Part of the review fix plan (Phase 2). The dead-code items (Validations, EqualityCompererCreator) are intentionally left in place for upcoming feature work.
