### PR TITLE
Add DI integration tests for AddSimpleSettings

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/ExistForAll.SimpleSettings.UnitTests/DependencyInjection/AddSimpleSettingsIntegrationTests.cs
+++ b/src/Tests/ExistForAll.SimpleSettings.UnitTests/DependencyInjection/AddSimpleSettingsIntegrationTests.cs
@@ -1,0 +1,80 @@
+using System;
+using ExistForAll.SimpleSettings.Binder;
+using ExistForAll.SimpleSettings.Extensions.GenericHost;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExistForAll.SimpleSettings.UnitTests.DependencyInjection
+{
+	public class AddSimpleSettingsIntegrationTests
+	{
+		// Discovered by the "Settings" suffix; the default SectionNameFormatter -> "DiExampleSettings".
+		private const string Section = "DiExampleSettings";
+
+		[Test]
+		public async Task AddSimpleSettings_ResolvesSettingsInterface_WithBoundValues()
+		{
+			var collection = new InMemoryCollection();
+			collection.Add(Section, nameof(IDiExampleSettings.Name), "resolved-value");
+
+			var services = new ServiceCollection();
+			services.AddSimpleSettings(o =>
+			{
+				o.AddAssemblies(new[] { typeof(IDiExampleSettings).Assembly });
+				o.AddSectionBinder(new InMemoryBinder(collection));
+			});
+
+			var provider = services.BuildServiceProvider();
+			var settings = provider.GetRequiredService<IDiExampleSettings>();
+
+			await Assert.That(settings.Name).IsEqualTo("resolved-value");
+		}
+
+		[Test]
+		public async Task AddSimpleSettings_RegistersSettingsAsSingleton()
+		{
+			var services = new ServiceCollection();
+			services.AddSimpleSettings(o => o.AddAssemblies(new[] { typeof(IDiExampleSettings).Assembly }));
+
+			var provider = services.BuildServiceProvider();
+			var first = provider.GetRequiredService<IDiExampleSettings>();
+			var second = provider.GetRequiredService<IDiExampleSettings>();
+
+			// The scanned settings are registered as singleton instances.
+			await Assert.That(ReferenceEquals(first, second)).IsTrue();
+		}
+
+		[Test]
+		public async Task AddSimpleSettings_RegistersSettingsProvider_ThatBindsValues()
+		{
+			var collection = new InMemoryCollection();
+			collection.Add(Section, nameof(IDiExampleSettings.Name), "from-provider");
+
+			var services = new ServiceCollection();
+			services.AddSimpleSettings(o =>
+			{
+				o.AddAssemblies(new[] { typeof(IDiExampleSettings).Assembly });
+				o.AddSectionBinder(new InMemoryBinder(collection));
+			});
+
+			var provider = services.BuildServiceProvider();
+			var settingsProvider = provider.GetRequiredService<ISettingsProvider>();
+
+			var settings = settingsProvider.GetSettings<IDiExampleSettings>();
+
+			await Assert.That(settings.Name).IsEqualTo("from-provider");
+		}
+
+		[Test]
+		public async Task AddSimpleSettings_NullAction_Throws()
+		{
+			var services = new ServiceCollection();
+
+			await Assert.That(() => services.AddSimpleSettings(null!)).Throws<ArgumentNullException>();
+		}
+
+		public interface IDiExampleSettings
+		{
+			string Name { get; set; }
+		}
+	}
+}

--- a/src/Tests/ExistForAll.SimpleSettings.UnitTests/ExistForAll.SimpleSettings.UnitTests.csproj
+++ b/src/Tests/ExistForAll.SimpleSettings.UnitTests/ExistForAll.SimpleSettings.UnitTests.csproj
@@ -11,11 +11,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="TUnit" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Core\ExistAll.SimpleConfig.Extensions.Binders\ExistForAll.SimpleSettings.Binders.csproj" />
     <ProjectReference Include="..\..\Core\ExistForAll.SimpleSettings.Core.AspNet\ExistForAll.SimpleSettings.Core.AspNet.csproj" />
     <ProjectReference Include="..\..\Core\ExistForAll.SimpleSettings\ExistForAll.SimpleSettings.csproj" />
+    <ProjectReference Include="..\..\Core\ExistForAll.SimpleSettings.Extensions.GenericHost\ExistForAll.SimpleSettings.Extensions.GenericHost.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Adds integration coverage for `AddSimpleSettings` — the Generic Host / DI path, the library's headline feature, which previously had **zero** tests.

## Tests — `Tests/.../DependencyInjection/AddSimpleSettingsIntegrationTests.cs`

Real `ServiceCollection` → `BuildServiceProvider()` flow (no mocks):
- **Resolves with bound values** — `AddSimpleSettings` with an in-memory binder; resolve the interface and assert the bound value.
- **Singleton registration** — two resolves of the same interface return the same instance.
- **`ISettingsProvider` binds values** — resolve the provider; `GetSettings<T>()` returns a correctly-bound instance.
- **Null action throws** — `AddSimpleSettings(null)` → `ArgumentNullException`.

## Wiring
- Test project now references the `Extensions.GenericHost` project.
- Adds `Microsoft.Extensions.DependencyInjection` (Central Package Management, 10.0.9 to match the other Extensions) for `ServiceCollection`/`BuildServiceProvider`.

## Notes
- Non-breaking (tests + test-project deps only). `dotnet test` from `src/` → **100 green** (net8.0 + net10.0).
- Intentionally does **not** assert `ISettingsProvider`'s fresh-vs-cached instance identity — that behavior is slated to change (provider caching / reload), so the tests assert values bind, not instance semantics.

Part of the review fix plan (Phase 4 / T3).
