### PR TITLE
Add fix plan and refresh the session handoff

### DIFF
--- a/FIX-PLAN.md
+++ b/FIX-PLAN.md
@@ -1,0 +1,246 @@
+# SimpleSettings — Fix Plan
+
+_Derived from the 2026-07-10 three-part review (architecture · tests · performance). Every finding below was verified against source with file:line. Work items are self-contained and ordered so they can be implemented one at a time._
+
+## Progress (2026-07-12)
+- **Done & merged:** B1, B2, B4, B5, B9 + T1, T2 (PR #8) · BindingContext test (PR #10) · D3 namespace typo (PR #11) · T3 DI integration tests (PR #12). Suite: 78 → **100 green**.
+- **Open:** solution rename `ExistAll.SimpleConfig.slnx` → `SimpleSettings.slnx` (PR #13 — part of A2).
+- **Held — do NOT delete (feature work coming):** D1 Validations (reconcile with the `validate-settings` branch) · D2 EqualityCompererCreator.
+- Running status lives in `SESSION-HANDOFF.md`.
+
+## How to work this plan
+- **Build/test from `src/`** (`global.json` opts into Microsoft.Testing.Platform for TUnit). `dotnet test` from `src/`. Only the net10 runtime is installed locally → net8 is build-only locally; CI runs both.
+- **Baseline:** 78 tests green on `master` @ `febaaba`.
+- **Breaking changes are FREE right now.** Only `2.0.0-alpha.0.110` is published; there is **no stable `v*` tag** yet (the `version-*` tags belong to the dead legacy `ExistAll.SimpleConfig` package). Do all breaking cleanup (dead API removal, namespace rename) **before** cutting the first `v2.0.0-beta`.
+- **Pairing:** where a test is marked _“pairs with Bx”_, commit the test **with** the fix so the fix ships with its regression guard. Tests marked _“fails first”_ are expected to be red against current `master` — write them, watch them fail, then apply the fix.
+- Suggested commit granularity: one item = one commit (or one small PR per phase).
+
+## Legend
+`Sev` = High / Med / Low · `Eff` = S (≤30 min) / M (hours) / L (day+) · `Break` = public API/behavior break?
+
+---
+
+## Summary checklist
+
+**Phase 1 — Correctness bugfixes (one-liners, non-breaking, highest ROI)**
+- [ ] B1 · Register `EnumTypeConverter` — enum binding is broken · Sev High · Eff S
+- [ ] B2 · Invariant culture in `DefaultTypeConverter` — locale data corruption · Sev High · Eff S
+- [ ] B4 · Fix `BindingContext.PropertyType` (returns the interface, not the property type) · Sev Med · Eff S
+- [ ] B5 · Fix validator contradiction (can’t null `AttributeType`) · Sev Med · Eff S
+- [ ] B9 · Fix broken error-message interpolation in `Resources` · Sev Low · Eff S
+
+**Phase 2 — Dead code & naming (do while pre-stable; breaking)**
+- [ ] D1 · Delete (or wire) the dead `Validations` API + `ValidatorType` · Sev Med · Eff M · **Break**
+- [ ] D2 · Delete (or fix+wire) `EqualityCompererCreator` (dead + invalid IL) · Sev Med · Eff S
+- [ ] D3 · Fix the `ExistsForAll` namespace typo in the Binders package · Sev Med · Eff S · **Break**
+
+**Phase 3 — Correctness/feature (needs design)**
+- [ ] C1 · Decide: support `List<T>`/`IList<T>`/`ICollection<T>` or document the `IEnumerable<T>`-only limit · Sev Med · Eff M
+- [ ] C2 · Introduce a public `SimpleSettingsException` base; make boundary-crossing exceptions public + structured · Sev Med · Eff M · **Break**
+- [ ] C3 · Decide reload / provider-vs-singleton semantics (see also P1) · Sev High · Eff M–L
+
+**Phase 4 — Tests (write-first shortlist, then broaden)**
+- [ ] T1 · Culture parse test (fails first · pairs with B2)
+- [ ] T2 · Enum-from-string test (fails first · pairs with B1)
+- [ ] T3 · DI / Generic-Host integration tests (headline feature, 0 coverage today)
+- [ ] T4 · `ValuesPopulator` unit tests (precedence + exception wrappers)
+- [ ] T5 · `TypeConverter` unit tests (null / nullable / empty-enumerable / attribute)
+- [ ] T6 · Converter unit tests (array / enumerable / Uri / DateTime + `List<T>` doc test)
+- [ ] T7 · `SettingsClassGenerator` caching + concurrency stress; collection not-found; binder edge cases
+
+**Phase 5 — Performance**
+- [ ] P0 · Upgrade the benchmark harness (MemoryDiagnoser + phase-split + fixtures) — do first, to measure P1–P3
+- [ ] P1 · Cache built instance on the `ISettingsProvider` resolve path · Sev High · Eff S
+- [ ] P2 · Memoize `ExtractTypeProperties` + fix O(n²) dedup · Sev High · Eff S
+- [ ] P3 · Cached compiled “settings plan” (emit setters, hoist names, cache converters) · Sev High · Eff L
+- [ ] Q1–Q5 · Quick wins (GetEnumerator, OrdinalIgnoreCase, env-binder, type-cache, dead ctor checks)
+- [ ] P4 · De-reflect array/enumerable converters · Sev Med · Eff M
+- [ ] P5 · Resolve config section once per type, not per property · Sev Med · Eff M
+
+**Phase 6 — Architecture strategy**
+- [ ] A1 · Decide AOT/trim story; annotate `[RequiresDynamicCode]`/`[RequiresUnreferencedCode]` and/or plan a source generator · Sev High · Eff M–L
+- [ ] A2 · Consolidate naming: `ExistAll` / `ExistsForAll` → `ExistForAll` (folder, `.slnx`, `Company`, benchmark) · Sev Low · Eff M
+- [ ] A3 · `Core.AspNet` ships no public type — make `Environments` public or drop the package · Sev Med · Eff S
+- [ ] A4 · Float `Microsoft.Extensions.*` floor per-TFM (don’t force net8 consumers to 10.x) · Sev Med · Eff S
+- [ ] A5 · Make `SettingsHolder`/`ISettingsHolder` internal (leaked detail) · Sev Low · Eff S · **Break**
+- [ ] A6 · Fix command-line parsing of quoted values / exe path · Sev Med · Eff M
+
+---
+
+# Phase 1 — Correctness bugfixes
+
+### B1 · Register `EnumTypeConverter`  — Sev High · Eff S · non-breaking
+**Problem:** `EnumTypeConverter` exists (`src/Core/ExistForAll.SimpleSettings/Conversion/EnumTypeConverter.cs`) but is **never registered**. `TypeConvertersCollections` adds only DateTime/Uri/Array/Enumerable/Default (`src/Core/ExistForAll.SimpleSettings/Conversion/TypeConvertersCollections.cs:9-13`). An enum property bound from a string therefore falls through to `DefaultTypeConverter` → `Convert.ChangeType("Monday", typeof(DayOfWeek))` → `InvalidCastException`.
+**Fix:** register it immediately before `DefaultTypeConverter` (order matters — `DefaultTypeConverter.CanConvert` always returns `true`):
+```csharp
+AddLast(new EnumerableTypeConverter(settingsOptions, this));
+AddLast(new EnumTypeConverter());        // <-- add (parameterless ctor)
+AddLast(new DefaultTypeConverter());
+```
+**Verify:** T2 goes green. Consider (separately) whether `Enum.Parse` should be case-insensitive and/or `Enum.IsDefined`-checked (`EnumTypeConverter.cs:15` is case-sensitive with no defined-value check) — capture as a follow-up decision, not part of this fix.
+
+### B2 · Invariant culture in `DefaultTypeConverter`  — Sev High · Eff S · non-breaking
+**Problem:** `src/Core/ExistForAll.SimpleSettings/Conversion/DefaultTypeConverter.cs:14` calls `System.Convert.ChangeType(value, settingsType)` with no `IFormatProvider`, so `double`/`decimal`/`float` parse under `CultureInfo.CurrentCulture`. On a `de-DE` host, `"1.5"` → `15` or throws — silent data corruption.
+**Fix:**
+```csharp
+using System.Globalization;
+...
+return System.Convert.ChangeType(value, settingsType, CultureInfo.InvariantCulture);
+```
+**Verify:** T1 goes green.
+
+### B4 · Fix `BindingContext.PropertyType`  — Sev Med · Eff S · behavior fix (public)
+**Problem:** `src/Core/ExistForAll.SimpleSettings/BindingContext.cs:38` sets `PropertyType = propertyInfo.DeclaringType!` — the **declaring settings interface**, not the property’s type. This is public surface consumed by custom `ISectionBinder` authors. (Confirmed: no internal code reads `context.PropertyType`, so the fix is safe.)
+**Fix:** `PropertyType = propertyInfo.PropertyType;`  Also delete the dead null-checks at `BindingContext.cs:31-32` (`string.Equals(x, null, …)` is always false after the `x == null` guards above).
+**Verify:** add an assertion `context.PropertyType == typeof(TheProperty)` (fails first).
+
+### B5 · Fix validator contradiction  — Sev Med · Eff S · non-breaking
+**Problem:** `src/Core/ExistForAll.SimpleSettings/Core/SettingsOptionsValidator.cs:10-18` allows any one of Attribute/Interface/Suffix indication, but line 17 then **unconditionally** requires `AttributeType` to be an `Attribute`. Setting `AttributeType = null` (to use interface/suffix only) makes `IsAssignableFrom(null)` false → throws `SettingsOptionNonAttributeException(null!)`, which NREs building its own message.
+**Fix:** guard the check:
+```csharp
+if (settingsOptions.AttributeType != null &&
+    !typeof(Attribute).GetTypeInfo().IsAssignableFrom(settingsOptions.AttributeType))
+    throw new SettingsOptionNonAttributeException(settingsOptions.AttributeType);
+```
+**Verify:** T-row asserting `AttributeType=null` + non-empty suffix validates without throwing.
+
+### B9 · Fix broken error-message interpolation  — Sev Low · Eff S · non-breaking
+**Problem:** `src/Core/ExistForAll.SimpleSettings/Resources.cs:46` is a verbatim (`@`) string with no `$`, so users see the literal `[{typeName}]`. Also `:49` has a stray `$` inside an interpolated string (`[${type.FullName}]`).
+**Fix:** add `$` on line 45/46 (`$@"[{typeName}] is not an interface…"`); remove the stray `$` on line 49 (`[{type.FullName}]`).
+**Verify:** existing suite stays green; optional message assertion.
+
+---
+
+# Phase 2 — Dead code & naming (breaking — do while pre-stable)
+
+### D1 · Delete or wire the dead `Validations` API  — Sev Med · Eff M · **Break**
+**Problem:** the entire `src/Core/ExistForAll.SimpleSettings/Validations/*` (`ISettingsValidator`, `ISettingValidation<T>`, `ValidationContext`, `ValidationContextOfT`, `ValidationResult`, `ValidationError`) plus `SettingsPropertyAttribute.ValidatorType` (`SettingsPropertyAttribute.cs:16`) are **public but referenced nowhere** — no `.Validate(` call exists in the pipeline (grep-confirmed). Ships a contract that silently does nothing.
+**Fix — pick one:**
+- **(Recommended, fast)** Delete the `Validations/` folder and `SettingsPropertyAttribute.ValidatorType`.
+- **(Feature)** Wire validation into `ValuesPopulator.PopulateInstanceWithValues` after conversion: resolve `ValidatorType`/registered validators, run them, aggregate `ValidationError`s, throw a typed exception on failure. Larger; treat as its own feature spec.
+**Verify:** solution builds; suite green. If wiring, add validation tests.
+
+### D2 · Delete or fix+wire `EqualityCompererCreator`  — Sev Med · Eff S
+**Problem:** `src/Core/ExistForAll.SimpleSettings/Core/Reflection/EqualityCompererCreator.cs` has **0 references** (grep-confirmed) and `SettingsClassGenerator.cs:48` discards the field list (`out _`). It’s also **buggy**: `Emit(OpCodes.Ldc_I4)` at `:38` uses the no-operand overload (invalid IL — proof it never ran), and `DeclareLocal(typeBuilder.DeclaringType!)` at `:18` is null for a top-level generated type.
+**Fix — pick one:**
+- **(Recommended)** Delete `EqualityCompererCreator.cs` + `IEqualityCompererCreator.cs` (both `internal`, non-breaking).
+- **(Feature)** Fix the IL (`Emit(OpCodes.Ldc_I4_0)` / correct operand; local type = the `TypeBuilder`), capture the fields from `PropertyCreator.CreateAnonymousProperties(..., out var fields)`, and call `CreateEqualsMethod`/`CreateGetHashCodeMethod` in `SettingsClassGenerator.GenerateType`. Add value-equality tests.
+**Verify:** builds; suite green.
+
+### D3 · Fix the `ExistsForAll` namespace typo  — Sev Med · Eff S · **Break**
+**Problem:** one file in the Binders package declares `namespace ExistsForAll.SimpleSettings.Binders` (`src/Core/ExistAll.SimpleConfig.Extensions.Binders/CommandLineSettingsBinder.cs:7`) while its 6 siblings use `ExistForAll.SimpleSettings.Binders`. The csproj’s `<RootNamespace>` is also the typo (`ExistForAll.SimpleSettings.Binders.csproj:5` = `ExistsForAll…`). Consumers must import two namespaces for one package.
+**Fix:** change `CommandLineSettingsBinder.cs:7` to `ExistForAll.SimpleSettings.Binders`; fix `<RootNamespace>` to `ExistForAll.SimpleSettings.Binders`. Remove the now-redundant `using ExistsForAll.SimpleSettings.Binders;` in `SettingsBuilderFactoryExtensions.cs` if present.
+**Verify:** builds; suite green.
+
+---
+
+# Phase 3 — Correctness / feature (design first)
+
+### C1 · `List<T>`/`IList<T>`/`ICollection<T>` support  — Sev Med · Eff M
+**Problem:** `TypeExtensions.IsEnumerable` (`src/Core/ExistForAll.SimpleSettings/Core/Reflection/TypeExtensions.cs:32-37`) matches **only** the exact `IEnumerable<>`. So `List<int>`, `IList<int>`, `ICollection<int>` properties fall through to `DefaultTypeConverter` and throw.
+**Fix — decide:** (a) document the limitation and throw a clear error, or (b) broaden `EnumerableTypeConverter.CanConvert` to handle assignable collection interfaces/`List<T>` and return a compatible instance. Coordinate with P4.
+**Verify:** T6 doc test, upgraded to a positive test if (b).
+
+### C2 · Public exception base + structured data  — Sev Med · Eff M · **Break**
+**Problem:** 9 exception types derive straight from `Exception` (no common base — can’t `catch (SimpleSettingsException)`); some are `internal` yet escape the public build path (uncatchable by type); context (binder/section/key/type) lives only in message strings; `TypeConverter.cs:62` throws a bare `Exception`.
+**Fix:** add `public abstract class SimpleSettingsException : Exception`; reparent all library exceptions; make boundary-crossing ones public; expose context as properties; replace the bare `Exception` (ties into D-work). Add the standard ctor set.
+**Verify:** builds; suite green; add a `catch (SimpleSettingsException)` test.
+
+### C3 · Reload / provider-vs-singleton semantics  — Sev High · Eff M–L
+**Problem:** DI registers startup-built **singletons** (`ServicesSettingsBuilderExtensions.cs:37-42`), but `ISettingsProvider.GetSettings` **re-binds a fresh instance every call** (`SettingsBuilder.cs:99-108`) — so `GetService<IFoo>()` and `provider.GetSettings<IFoo>()` can return different objects/values. No `IOptionsMonitor`-style reload exists (acknowledged by the `// replace this…` TODO at `ServicesSettingsBuilderExtensions.cs:35`).
+**Fix — decide the contract:** either (a) cache in the provider so both paths agree (implemented by **P1**), or (b) add a snapshot/change-token reload path. Document whichever you choose. This is the defining feature vs `IOptions` — resolve before the “replacement” claim ships.
+**Verify:** T3 pins the chosen semantics.
+
+---
+
+# Phase 4 — Tests
+
+> Match existing TUnit conventions: `[Test] async Task`, `[Arguments(...)]`, `[NotInParallel("…")]` for process-global state, `await Assert.That(...).IsEqualTo/.Throws<T>()`, nested `public interface` fixtures per class, build via `SettingsBuilder.CreateBuilder(x => …)`. New files under `src/Tests/ExistForAll.SimpleSettings.UnitTests/`.
+
+### T1 · Culture parse (fails first · pairs with B2)
+`Conversion/DefaultTypeConverterTests.cs` — `[NotInParallel]`, set `CultureInfo.CurrentCulture = new("de-DE")` in a try/finally; bind a `double` from `"1.5"`, assert `1.5`; `decimal` from `"1234.56"`; int baseline `"42"`→`42`.
+
+### T2 · Enum-from-string (fails first · pairs with B1)
+`Conversion/EnumConversionTests.cs` — in-memory `"Monday"` → `DayOfWeek.Monday` (fails today); `DefaultValue = DayOfWeek.Monday` path (works today) for contrast; converter-level case-sensitivity + undefined-value behavior (documents current `Enum.Parse`).
+
+### T3 · DI / Generic-Host integration (headline feature — 0 coverage)
+**Prep (one-time):** add to `src/Tests/ExistForAll.SimpleSettings.UnitTests/ExistForAll.SimpleSettings.UnitTests.csproj`:
+```xml
+<ProjectReference Include="..\..\Core\ExistForAll.SimpleSettings.Extensions.GenericHost\ExistForAll.SimpleSettings.Extensions.GenericHost.csproj" />
+<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+```
+`DependencyInjection/AddSimpleSettingsIntegrationTests.cs`:
+- resolves a settings interface with bound values (in-memory source);
+- registered as **singleton** (two resolves ⇒ `ReferenceEquals`);
+- `ISettingsProvider.GetSettings<T>()` behavior per the C3 decision;
+- `AddSimpleSettings(null)` → `ArgumentNullException`.
+
+### T4 · `ValuesPopulator` unit (internal ctor + fakes)
+`Core/ValuesPopulatorTests.cs` — binder-throws ⇒ `SettingsBindingException` (inner preserved); conversion-throws ⇒ `SettingsPropertyValueException` (carries type/value/property); later binder overrides earlier; no binder ⇒ attribute default survives.
+
+### T5 · `TypeConverter` unit
+`Core/TypeConverterTests.cs` — null→value-type default; null→`IEnumerable<int>` empty (not null); `Nullable<int>` strip+convert; allow-empty-false throw; attribute `ConverterType` bypasses the collection.
+
+### T6 · Converters
+`Conversion/{Array,Enumerable,Uri,DateTime}…Tests.cs` — split delimiter (default + custom + empty-entry removal); single-value→collection; result is concrete `List<T>`; Uri from string + non-string throws; DateTime custom format + invariant culture; **`List<int>` doc test** (see C1).
+
+### T7 · Generator / collection / binders
+`SimpleSettings/SettingsClassGeneratorConcurrencyTests.cs` — same interface twice ⇒ `ReferenceEquals`; extraction-fails ⇒ `TypeGenerationException`; `Parallel.For` stress on `GenerateType(typeof(IRoot))` (the check-then-`DefineType` at `SettingsClassGenerator.cs:37-44` is unsynchronized — expected flaky, documents the hazard, see P-note). Plus `SettingsCollection` not-found/try-get/duplicate-add; command-line + env-var edge cases; 3-binder precedence extension.
+
+---
+
+# Phase 5 — Performance
+
+> Two cost phases: **startup** (once per discovered type — IL emit + reflective populate; dominates wall-clock) and **per-resolve** (DI-singleton path is already free; only `ISettingsProvider.GetSettings` re-pays). Fixing the populate/convert path helps both.
+
+### P0 · Benchmark harness upgrade (do first)  — Eff M
+`src/performance/ExistsForAll.SimpleSettings.Benchmark/` currently measures only cold `ScanAssemblies` and has no allocation view. Add: `[MemoryDiagnoser]`; split into `ColdScan` / `WarmResolve_Provider` / `WarmResolve_DiSingleton`; `[Params]` property count 1/10/50; array-heavy, enum/DateTime/Uri, and deep-hierarchy fixtures; a converter-selection microbenchmark. Capture a baseline before P1–P5; gate on **mean** and **Allocated**.
+
+### P1 · Cache built instance on the provider path  — Sev High · Eff S
+`SettingsProvider.GetSettings` → `SettingsBuilder.GetSettings` → `InnerBuild(Type)` (`src/Core/ExistForAll.SimpleSettings/SettingsBuilder.cs:99-108`) runs `Activator.CreateInstance` + full populate on **every** call. Memoize by `Type` (`ConcurrentDictionary<Type, object>`), or serve from the startup-built `SettingsCollection`. ~99% cut on repeat provider resolves. **Also implements C3(a)** — decide C3 first.
+
+### P2 · Memoize property extraction + fix O(n²) dedup  — Sev High · Eff S
+`TypePropertiesExtractor.ExtractTypeProperties` (`src/Core/ExistForAll.SimpleSettings/Core/Reflection/TypePropertiesExtractor.cs:16-27`) does LINQ + an O(n²) `Where(p => properties.All(...))` dedup, and is called twice per type (`SettingsClassGenerator.cs:42` + `ValuesPopulator.cs:31`) with no shared cache. Add `ConcurrentDictionary<Type, PropertyInfo[]>`; replace the dedup with a `HashSet<string>`; share one cache across generator + populator.
+
+### P3 · Cached compiled “settings plan”  — Sev High · Eff L (biggest ceiling)
+The populate loop (`src/Core/ExistForAll.SimpleSettings/ValuesPopulator.cs:36-55`) is reflection-saturated: reflective `property.SetValue` (`:55`, boxes value types); `GetSectionName` recomputed inside both loops though it’s constant per type; `GetPropertyName` recomputed per binder; `SettingsPropertyAttribute` read ~3×/property (`:36-40` + `TypeConverter.cs:36`). Build a per-interface `SettingsPlan` once (`ConcurrentDictionary<Type, SettingsPlan>`) holding: section name (once), and per property — resolved key, default value, chosen converter, and a **compiled setter** (emit the populate into the generated class in `PropertyCreator`, or a compiled `Action<object,object?>`). Folds in converter caching (below).
+
+### Quick wins  — Eff S each
+- **Q1** `SettingsCollection.GetEnumerator` (`SettingsCollection.cs:52`) rebuilds a whole `Dictionary` per enumeration → `yield return` over the existing dictionary.
+- **Q2** `SettingsTypesExtractor.cs:32` `Name.ToLower().EndsWith(suffix.ToLower())` → `EndsWith(suffix, StringComparison.OrdinalIgnoreCase)` (also fixes an ordinal-correctness smell); hoist the trimmed suffix. (Startup allocs across all scanned types.)
+- **Q3** `EnvironmentVariableBinder` (`EnvironmentVariableBinder.cs:27-39`) news a `StringBuilder` per property + double dictionary lookup → fast-path `context.Key` when no prefix/formatter; single lookup.
+- **Q4** `SettingsClassGenerator.cs:37` string-keyed assembly `GetType(...Replace("+"…))` per generate → `Dictionary<Type, Type>` cache.
+- **Q5** `BindingContext.cs:31-32` dead null-checks per allocation (also covered by B4).
+
+### P4 · De-reflect array/enumerable converters  — Sev Med · Eff M
+`TypeConverter.cs:22-23` (empty enumerable via `Enumerable.Empty` `MakeGenericMethod().Invoke()`), `ArrayTypeConverter.cs:40,48-52` (`Activator.CreateInstance(List<>)` + reflected `ToArray`), `EnumerableTypeConverter.cs:40`. Use `Array.Empty<T>()` factories, `Array.CreateInstance(elementType, n)` + indexed assignment, and cache any unavoidable `MethodInfo`/generic instantiations per element type. (`ArrayTypeConverter`/`EnumerableTypeConverter` are near-duplicates — DRY them here.)
+
+### P5 · Resolve config section once per type  — Sev Med · Eff M
+`ConfigurationBinder.BindPropertySettings` (`ConfigurationBinder.cs:25-33`) calls `_configuration.GetSection(...)` **per property**; the section is constant per type. Resolve the `IConfigurationSection` once per (type, section) — pass section context via the plan (P3) or cache per section string. Touches the binder/context contract.
+
+---
+
+# Phase 6 — Architecture strategy
+
+### A1 · AOT / trimming story  — Sev High · Eff M–L
+The engine is `Reflection.Emit` (`SettingsClassGenerator.cs:26`) + `MakeGenericType/Method` + `GetExportedTypes`, with **zero** `[RequiresDynamicCode]`/`[RequiresUnreferencedCode]` annotations on net8/net10 TFMs → silently breaks in Native AOT / trimmed apps. **Decide:** annotate the public entry points (honest consumer warnings) and/or plan a source-generator path replacing runtime emit. At minimum, document the limitation in the README before the stable release. Consider `AssemblyBuilderAccess.Run` instead of `RunAndCollect` (`:26`) unless unloading is required.
+
+### A2 · Consolidate naming  — Sev Low · Eff M
+Three spellings repo-wide: `ExistAll` (folder `ExistAll.SimpleConfig.Extensions.Binders`, `src/ExistAll.SimpleConfig.slnx`), `ExistsForAll` (`Company` in `Directory.Build.props`, benchmark project), `ExistForAll` (everything else). Pick `ExistForAll`; rename folder + `.slnx` + `Company` + benchmark namespace. Batch with D3.
+
+### A3 · `Core.AspNet` exports nothing  — Sev Med · Eff S
+`Environments` is `internal` (`src/Core/ExistForAll.SimpleSettings.Core.AspNet/Environments.cs:3`) and `Info.cs` only exposes to tests, so the published `ExistForAll.SimpleSettings.Core.AspNet` package has no consumable public type. Make `Environments` public, or drop the package.
+
+### A4 · Dependency floor per-TFM  — Sev Med · Eff S
+`src/Directory.Packages.props` pins `Microsoft.Extensions.*` to `10.0.9` for **both** TFMs, pulling net8 consumers of the binders/DI packages up to the 10.x assemblies. Float the floor to the lowest supported (`8.0.x`) via per-TFM `PackageVersion`, or justify the pin.
+
+### A5 · Hide `SettingsHolder`  — Sev Low · Eff S · **Break**
+`SettingsHolder`/`ISettingsHolder` are `public` but never appear in a public signature (only built internally in `SettingsCollection.cs:15`). Make internal.
+
+### A6 · Command-line quoted-value parsing  — Sev Med · Eff M
+The command-line binder splits `Environment.CommandLine.Trim().Split(' ')` (in `src/Core/ExistAll.SimpleConfig.Extensions.Binders/SettingsBuilderFactoryExtensions.cs`), which breaks quoted values with spaces and includes the executable path. Parse args properly (respect quotes; skip arg[0]).
+
+---
+
+## Recommended first PR
+**Phase 1 (B1, B2, B4, B5, B9) + their tests (T1, T2)** — small, non-breaking, and each fix ships with a regression guard. Then Phase 2 (breaking cleanup) while still pre-stable, then Phase 4 tests, then Phase 5 perf (P0 → P1 → P2 → quick wins → P3).

--- a/SESSION-HANDOFF.md
+++ b/SESSION-HANDOFF.md
@@ -1,103 +1,49 @@
-# SESSION HANDOFF — SimpleSettings modernization
+# SESSION HANDOFF — SimpleSettings
 
-_Last updated: 2026-07-09 · owner: Guy Ludvig (guy@frontegg.com)_
+_Last updated: 2026-07-12 · owner: Guy Ludvig (guy@frontegg.com)_
 
 ## TL;DR
-The modernization (xUnit → TUnit, Central Package Management, latest NuGets, `.slnx`, legacy cleanup) is **complete, committed, pushed, and open as PR #5**:
-https://github.com/existall/SimpleSettings/pull/5
+We ran a three-specialist code review (architecture · tests · performance) and have been shipping the fixes as small PRs. **Five PRs merged this session; one open (#13).** Test suite went **78 → 100 green** (net8.0 + net10.0). The full prioritized plan lives in **`FIX-PLAN.md`** (repo root, git-ignored/untracked — read it first for detail).
 
-Build is green (**0 warnings / 0 errors**) and **39/39 tests pass**. **One item is deferred:** the GitHub Actions CI workflow was NOT updated (the available token lacked the `workflow` scope). The ready-to-apply YAML is in the appendix below.
+The repo is still **pre-stable** (no `v*` tag; only auto-alphas published), so **breaking changes are free** — do the breaking cleanup now.
 
-## Environment
-- Repo: `existall/SimpleSettings` · working dir: `/Users/guyludvig/frontegg/development/open-source/SimpleSettings`
-- The solution lives under `src/` → `src/ExistAll.SimpleConfig.slnx`
-- .NET SDK **10.0.301**; **only the .NET 10 runtime is installed locally** (net8.0 compiles but its tests can only run where a net8.0 runtime exists, e.g. CI)
-- Target frameworks: libraries `net8.0;net10.0`; benchmark `net10.0`
+## Current state
+- Branch to be on next session: **`master`** (@ `9782f4b`, PR #12). Once #13 merges, `git checkout master && git pull`.
+- **Open PR #13** — `chore/rename-solution-to-simplesettings` → renames `src/ExistAll.SimpleConfig.slnx` to `src/SimpleSettings.slnx` + updates the 11 workflow references. Merge it, then continue.
+- Working tree carries two uncommitted, intentional-leftover edits (NOT part of any PR): `SESSION-HANDOFF.md` (this file) and `src/SimpleSettings.slnx` (a Solution-Items entry adding SESSION-HANDOFF.md — from the IDE). `FIX-PLAN.md` is untracked. Leave them unless you decide to commit.
+- Orphaned remote branches from #8–#12 are still on origin (merged); safe to delete anytime.
 
-## Current git state
-- Branch: `modernize/tunit-cpm-upgrade` (base `master` @ `65f209d`)
-- HEAD: `5b002e0` · working tree clean
-- PR: **#5 OPEN** (base `master`)
-- Commits (oldest → newest):
-  | Hash | Subject |
-  |------|---------|
-  | `b4e8b37` | Drop classic .NET Framework projects |
-  | `9ede951` | Adopt Central Package Management and shared build props; enable nullable |
-  | `8273e9d` | Upgrade NuGet packages to latest |
-  | `12a129d` | Migrate tests from xUnit to TUnit 1.58 |
-  | `5b002e0` | Modernize solution to .slnx and remove legacy build tooling |
+## What shipped this session
+Merged to `master` (all non-breaking except #11/#13 which are pre-stable breaking):
+- **#8** — five correctness bugfixes + regression tests: register `EnumTypeConverter` (enum-from-string was throwing); `InvariantCulture` in `DefaultTypeConverter` (locale parse bug); `BindingContext.PropertyType` = property's type not declaring interface; guard the options validator when `AttributeType` is null; fix two broken `Resources` message templates.
+- **#10** — `BindingContext.PropertyType` regression test (re-landed onto master; see stranding note below).
+- **#11** — fix the `ExistsForAll` → `ExistForAll` namespace typo in the Binders package (one file was a letter off).
+- **#12** — DI integration tests for `AddSimpleSettings` (headline feature, previously 0 coverage); wired the test project to `Extensions.GenericHost` + added `Microsoft.Extensions.DependencyInjection` via CPM.
 
-## Done
-- **TUnit 1.58** on Microsoft.Testing.Platform; all 11 test files migrated (`[Fact]`/`[Theory]`→`[Test]`/`[Arguments]`, awaited `Assert.That(...)`). Dropped `xunit`, `xunit.runner.visualstudio`, `Microsoft.NET.Test.Sdk`, and unused `NSubstitute`. Env-var tests carry `[NotInParallel("EnvironmentVariables")]` (TUnit parallelizes within a class by default).
-- **CPM**: `src/Directory.Packages.props`. **Shared props**: `src/Directory.Build.props` (`Nullable` + `ImplicitUsings` + `LangVersion latest` + package metadata folded in from the removed `version.props`). `src/global.json` (SDK pin + MTP test runner).
-- **Nullable** enabled repo-wide; all 138 resulting warnings resolved with annotations only (no behavior change).
-- **Upgrades**: `Microsoft.Extensions.*` → 10.0.9, BenchmarkDotNet → 0.15.8, TUnit 1.58.0.
-- **Solution/cleanup**: `.sln` → `.slnx`; removed the legacy `packages/` dir, Cake/AppVeyor scripts (`build.*`, both `appveyor.yml`), and the orphaned `ExistsForAll.SimpleConfig.Benchmark` project.
+Open: **#13** (solution rename, above).
 
-## Pending / next steps
-1. **Apply the CI workflow** (deferred). Two options:
-   - **GitHub web editor** (simplest — commits workflow files without a local `workflow`-scoped token): on the `modernize/tunit-cpm-upgrade` branch, edit `.github/workflows/dotnet.yml` and paste the YAML from the appendix.
-   - **Locally**: `gh auth refresh -h github.com -u guy-lud -s workflow`, then commit the appendix YAML to `.github/workflows/dotnet.yml` and push (see push recipe below).
-2. **PR #5** — review and merge.
-3. Optional: add reviewers/labels to PR #5.
+## Key decisions & context (carry forward)
+- **Validations API (D1) — HELD, do NOT delete.** The whole `Validations/*` namespace + `SettingsPropertyAttribute.ValidatorType` is public but never invoked. Owner intends to **build the validation feature in the near future** — there is already an existing **`validate-settings`** branch on origin to reconcile with. Wire it into `ValuesPopulator` (run validators after binding, aggregate errors, throw typed exception).
+- **`EqualityCompererCreator` (D2) — HELD too** by the same logic (internal, dead, and has a latent invalid-IL bug at `EqualityCompererCreator.cs:38`). Delete only if the owner decides value-equality on generated types isn't wanted.
+- **Pre-stable window:** no `v*` stable tag exists (the `version-*` tags are the dead legacy `ExistAll.SimpleConfig` package). Breaking API changes are free until the first `v2.0.0-beta`.
+- **Stacked-PR lesson:** #9 (a BindingContext test) was stacked on #8's branch and merged *there*; because #8 was squash-merged to master separately, #9 never reached master. Re-landed as #10. **Takeaway:** don't stack PRs on a branch that will be squash-merged — branch off master, or merge the base first.
+
+## Next priorities (ranked — detail in FIX-PLAN.md)
+1. **Merge #13**, then optionally finish the `SimpleConfig` naming (A2): rename the Binders *folder* `Core/ExistAll.SimpleConfig.Extensions.Binders/` (updates the `.slnx` project path + test csproj ref), then `docs/*`, `README.md`, `PackageTags`, a benchmark comment.
+2. **Validations feature (D1)** — owner-driven; reconcile with the `validate-settings` branch.
+3. **Performance (Phase 5):** P0 (benchmark harness — `[MemoryDiagnoser]` + phased scenarios) → **P1 (cache the `ISettingsProvider` instance)** which also fixes the C3 provider-vs-singleton divergence → P2 (memoize `ExtractTypeProperties` + fix O(n²) dedup) → P3 (compiled setter plan).
+4. **More engine tests:** T4 `ValuesPopulator` (precedence + exception wrappers), T5 `TypeConverter` (null/nullable/empty-enumerable/attribute), T6 converters, T7 generator caching + concurrency stress.
+5. **Architecture calls:** A1 (AOT/trim `[RequiresDynamicCode]`/`[RequiresUnreferencedCode]` — HIGH, it's a `Reflection.Emit` lib on net8/net10), C1 (`List<T>`/`IList<T>` support), C2 (public `SimpleSettingsException` base), C3 (reload/`IOptionsMonitor` — pairs with P1), A3 (`Core.AspNet` exports no public type), A4 (float `Microsoft.Extensions.*` floor per-TFM), A5 (make `SettingsHolder` internal), A6 (command-line quoted-arg parsing).
+
+## How releasing works (unchanged — durable)
+- **`ci.yml`** — on PRs to `master`: build + test (net8.0 + net10.0). **`release.yml`**:
+  - push to `master` → auto-publishes a MinVer height-based `-alpha` prerelease to nuget.org.
+  - manual **Release** (`workflow_dispatch`) with `channel` (beta/rc/stable) + `bump` (patch/minor/major) → computes the next version, tags `v*`, publishes, creates a GitHub Release. `dry_run: true` previews.
+- **Versioning = MinVer**, tag prefix `v`, baseline **2.0.0**. Keyless publish via NuGet Trusted Publishing (OIDC). First real release: Actions → Release → `channel: beta` (→ `v2.0.0-beta.1`); use `dry_run` first.
+- Both workflows invoke the solution by name — now **`SimpleSettings.slnx`** (via #13).
 
 ## Gotchas a new session MUST know
-
-### Pushing to this repo
-- The active `gh` account **`guy-frontegg` is read-only** on `existall/SimpleSettings`. **`guy-lud`** has push/admin.
-- A **global git rewrite** turns HTTPS into SSH: `url."git@github.com:".insteadOf https://github.com/`, and the loaded SSH key authenticates as `guy-frontegg` (denied). So a normal `git push` fails.
-- Neither `gh` token has the **`workflow`** scope (blocks pushing changes under `.github/workflows/`).
-- Recipe that works — push as `guy-lud` over real HTTPS (bypassing the SSH rewrite), then restore:
-  ```bash
-  gh auth switch -u guy-lud
-  GIT_CONFIG_GLOBAL=/dev/null git \
-    -c "url.https://github.com/existall/SimpleSettings.git.insteadOf=https://github.com/existall/SimpleSettings.git" \
-    -c credential.helper= -c credential.helper='!gh auth git-credential' \
-    push https://github.com/existall/SimpleSettings.git <branch>:<branch>
-  gh auth switch -u guy-frontegg   # restore original active account
-  ```
-
-### Building / testing
-- **Run `dotnet` from `src/`** so `global.json`'s Microsoft.Testing.Platform opt-in is found. From the repo root, `dotnet test` silently falls back to the legacy VSTest path and **fails on .NET 10**.
-- Build: `cd src && dotnet build ExistAll.SimpleConfig.slnx -c Release` → expect **0/0**.
-- Test (local; net10 only): `cd src && dotnet test ExistAll.SimpleConfig.slnx -c Release -f net10.0` → expect **39/39**.
-- net8.0 tests are build-only locally (no runtime); they run in CI once the workflow is applied.
-
-## Appendix — CI workflow to apply (`.github/workflows/dotnet.yml`)
-```yaml
-name: .NET
-
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup .NET (8.0 + 10.0)
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: |
-            8.0.x
-            10.0.x
-
-      # Run from src/ so global.json (which opts into Microsoft.Testing.Platform
-      # for TUnit) is discovered — running from the repo root falls back to the
-      # legacy VSTest path and fails on .NET 10.
-      - name: Restore
-        run: dotnet restore ExistAll.SimpleConfig.slnx
-        working-directory: src
-
-      - name: Build
-        run: dotnet build ExistAll.SimpleConfig.slnx --configuration Release --no-restore
-        working-directory: src
-
-      - name: Test (net8.0 + net10.0)
-        run: dotnet test ExistAll.SimpleConfig.slnx --configuration Release --no-restore
-        working-directory: src
-```
+- **Pushing / PRs:** the active `git`/`gh` identity is **read-only** on this repo; a separate account has push access. The exact recipe (SSH alias, account names, `gh` account-switch flow) lives in the assistant's **private project memory** (`simplesettings-push-access`) — deliberately kept out of this public file.
+- **Run `dotnet` from `src/`** (global.json opts into Microsoft.Testing.Platform for TUnit). Only the net10 runtime is installed locally → net8 tests are build-only locally; CI runs both. Do NOT prefix `cd <repo-root>` before `dotnet` — the solution lives in `src/`.
+- **`FIX-PLAN.md`** (repo root, untracked) is the full, prioritized fix plan with per-item file:line detail. It is NOT auto-injected — open it explicitly.
+- Commits/PRs here **omit** the Co-Authored-By / Generated-with trailer (project preference).


### PR DESCRIPTION
## Summary

Documentation only — no code changes.

- **`FIX-PLAN.md`** (new): the prioritized, per-item fix plan produced by the three-part code review (architecture · tests · performance), with a progress banner tracking what's merged.
- **`SESSION-HANDOFF.md`**: replaces the stale modernization-era handoff with a current one — the review, the fixes shipped this cycle (PRs #8/#10/#11/#12), key decisions (Validations and `EqualityCompererCreator` held for upcoming feature work), ranked next steps, and standing gotchas. The push/PR recipe is referenced via private notes rather than inlined.

Makes the next session self-briefing.
