### PR TITLE
Cache the settings provider path (P1, resolves C3)

### DIFF
--- a/src/Core/ExistForAll.SimpleSettings.Extensions.GenericHost/ServicesSettingsBuilderExtensions.cs
+++ b/src/Core/ExistForAll.SimpleSettings.Extensions.GenericHost/ServicesSettingsBuilderExtensions.cs
@@ -30,16 +30,18 @@ namespace ExistForAll.SimpleSettings.Extensions.GenericHost
                 action?.Invoke(options);
             });
 
-            var settingsProvider = settingsBuilder.ScanAssemblies(options!.Assemblies);
+            var settingsCollection = settingsBuilder.ScanAssemblies(options!.Assemblies);
 
-            // replace this with a replaceable settings provider to support time based Settingsuration
-
-            foreach (var settings in settingsProvider)
+            // Register each scanned interface as its startup-built instance, and hand that same
+            // collection to the provider so ISettingsProvider.GetSettings<T>() returns the very same
+            // instance as GetService<T>() (a lookup, not a re-bind). A future reload / IOptionsMonitor
+            // path would swap these snapshots out here.
+            foreach (var settings in settingsCollection)
             {
                 services.AddSingleton(settings.Key, settings.Value);
             }
 
-            services.AddSingleton<ISettingsProvider>(new SettingsProvider(settingsBuilder));
+            services.AddSingleton<ISettingsProvider>(new SettingsProvider(settingsCollection, settingsBuilder));
         }
     }
 }

--- a/src/Core/ExistForAll.SimpleSettings.Extensions.GenericHost/SettingsProvider.cs
+++ b/src/Core/ExistForAll.SimpleSettings.Extensions.GenericHost/SettingsProvider.cs
@@ -1,19 +1,27 @@
-﻿using System;
+using System;
 
 namespace ExistForAll.SimpleSettings.Extensions.GenericHost
 {
     internal class SettingsProvider : ISettingsProvider
     {
+        private readonly ISettingsCollection _settings;
         private readonly SettingsBuilder _settingsBuilder;
 
-        public SettingsProvider(SettingsBuilder configBuilder)
+        public SettingsProvider(ISettingsCollection settings, SettingsBuilder settingsBuilder)
         {
-            _settingsBuilder = configBuilder;
+            _settings = settings;
+            _settingsBuilder = settingsBuilder;
         }
 
         public object GetSettings(Type type)
         {
-            return _settingsBuilder.GetSettings(type);
+            // Serve the startup-built instance (the same object registered as the DI singleton) so that
+            // GetService<T>() and ISettingsProvider.GetSettings<T>() agree, and repeat resolves are a
+            // dictionary lookup rather than a full re-bind. Types that were never scanned fall back to
+            // building on demand.
+            return _settings.TryGetSettings(type, out var settings)
+                ? settings!
+                : _settingsBuilder.GetSettings(type);
         }
     }
 }

--- a/src/Tests/ExistForAll.SimpleSettings.UnitTests/DependencyInjection/AddSimpleSettingsIntegrationTests.cs
+++ b/src/Tests/ExistForAll.SimpleSettings.UnitTests/DependencyInjection/AddSimpleSettingsIntegrationTests.cs
@@ -65,6 +65,25 @@ namespace ExistForAll.SimpleSettings.UnitTests.DependencyInjection
 		}
 
 		[Test]
+		public async Task AddSimpleSettings_Provider_ReturnsTheSameInstanceAsTheContainer()
+		{
+			var services = new ServiceCollection();
+			services.AddSimpleSettings(o => o.AddAssemblies(new[] { typeof(IDiExampleSettings).Assembly }));
+
+			var provider = services.BuildServiceProvider();
+			var fromContainer = provider.GetRequiredService<IDiExampleSettings>();
+			var settingsProvider = provider.GetRequiredService<ISettingsProvider>();
+
+			var first = settingsProvider.GetSettings<IDiExampleSettings>();
+			var second = settingsProvider.GetSettings<IDiExampleSettings>();
+
+			// C3: the provider serves the startup-built singleton, so both resolution paths agree and
+			// repeat resolves return the same cached instance instead of re-binding a fresh one.
+			await Assert.That(ReferenceEquals(fromContainer, first)).IsTrue();
+			await Assert.That(ReferenceEquals(first, second)).IsTrue();
+		}
+
+		[Test]
 		public async Task AddSimpleSettings_NullAction_Throws()
 		{
 			var services = new ServiceCollection();

--- a/src/performance/ExistForAll.SimpleSettings.Benchmark/ResolveBenchmark.cs
+++ b/src/performance/ExistForAll.SimpleSettings.Benchmark/ResolveBenchmark.cs
@@ -10,8 +10,9 @@ namespace ExistForAll.SimpleSettings.Benchmark
 	/// <list type="bullet">
 	/// <item><c>ColdBuild</c> — a fresh <see cref="SettingsBuilder"/> per call: IL-emit the implementation
 	/// type into a new dynamic assembly + reflectively populate it (the per-type startup cost).</item>
-	/// <item><c>WarmResolve_Provider</c> — a primed builder re-binding a fresh instance every call. This is
-	/// exactly what <c>ISettingsProvider.GetSettings</c> does today, and the path P1 will cache.</item>
+	/// <item><c>WarmResolve_Provider</c> — a primed builder re-binding a fresh instance every call: the raw
+	/// <c>SettingsBuilder.GetSettings</c> re-bind cost. P1 makes <c>ISettingsProvider</c> serve the cached
+	/// collection for scanned settings instead, so its resolves drop toward <c>WarmResolve_DiSingleton</c>.</item>
 	/// <item><c>WarmResolve_DiSingleton</c> — resolving the startup-built singleton from a DI container
 	/// (what <c>AddSimpleSettings</c> registers via <c>AddSingleton(interface, instance)</c>).</item>
 	/// </list>


### PR DESCRIPTION
Implements **P1** and resolves **C3** using the contract chosen in review: **cache at the provider layer only** — Core's public `SettingsBuilder.GetSettings` is untouched (still fresh per call).

## Problem
`ISettingsProvider.GetSettings` re-bound a fresh instance on **every** call (`SettingsBuilder.GetSettings` → `Activator.CreateInstance` + full populate), while `AddSimpleSettings` registers the startup-built instances as DI singletons. So `GetService<T>()` and `provider.GetSettings<T>()` returned **different objects** (C3), and every provider resolve re-paid the bind cost.

## Change
- `SettingsProvider` now holds the startup-built `ISettingsCollection` and serves `TryGetSettings(type)` — the *same* instance registered as the DI singleton — falling back to `SettingsBuilder.GetSettings` for types that were never scanned.
- `AddSimpleSettings` hands that collection to the provider.

Result: `GetService<T>()` and `provider.GetSettings<T>()` return the **same cached instance**, and repeat provider resolves become a dictionary lookup instead of a full re-bind.

## Tests
- New regression test pins the contract: `GetService<T>()` and two successive `provider.GetSettings<T>()` calls are all `ReferenceEquals`.
- **51/51** pass on net10.0 (was 50); the existing provider/singleton tests stay green.

## Measuring it (P0 harness)
Because Core's builder is unchanged, the win is the gap the provider now crosses: `ResolveBenchmark.WarmResolve_Provider` (raw `SettingsBuilder.GetSettings` re-bind) → `WarmResolve_DiSingleton` (cached lookup). Post-P1 a scanned provider resolve costs the latter, not the former. I corrected that benchmark's doc comment to say so. A direct through-the-provider benchmark would require the fixtures to be scanned — happy to add one as a follow-up if you want the number in-harness.

Build clean on net8.0 + net10.0.
