### PR TITLE
Refresh the session handoff and fix-plan progress (through #17)

### DIFF
--- a/FIX-PLAN.md
+++ b/FIX-PLAN.md
@@ -3,8 +3,9 @@
 _Derived from the 2026-07-10 three-part review (architecture · tests · performance). Every finding below was verified against source with file:line. Work items are self-contained and ordered so they can be implemented one at a time._
 
 ## Progress (2026-07-12)
-- **Done & merged:** B1, B2, B4, B5, B9 + T1, T2 (PR #8) · BindingContext test (PR #10) · D3 namespace typo (PR #11) · T3 DI integration tests (PR #12). Suite: 78 → **100 green**.
-- **Open:** solution rename `ExistAll.SimpleConfig.slnx` → `SimpleSettings.slnx` (PR #13 — part of A2).
+- **Done & merged:** B1, B2, B4, B5, B9 + T1, T2 (PR #8) · BindingContext test (#10) · D3 namespace typo (#11) · T3 DI integration tests (#12) · solution rename (#13) · **A2 naming → ExistForAll (#15)** · **P0 benchmark harness (#16)** · **P1 provider cache + C3 decided/implemented (#17)**. Suite: 78 → **102 green** (51 per TFM · net8.0 + net10.0).
+- **Next:** P2 (memoize `ExtractTypeProperties` + replace the O(n²) dedup) — in progress.
+- **C3 — DECIDED (option 2):** cache in the provider only; Core `SettingsBuilder.GetSettings` unchanged; no reload. See #17.
 - **Held — do NOT delete (feature work coming):** D1 Validations (reconcile with the `validate-settings` branch) · D2 EqualityCompererCreator.
 - Running status lives in `SESSION-HANDOFF.md`.
 

--- a/SESSION-HANDOFF.md
+++ b/SESSION-HANDOFF.md
@@ -3,47 +3,42 @@
 _Last updated: 2026-07-12 · owner: Guy Ludvig (guy@frontegg.com)_
 
 ## TL;DR
-We ran a three-specialist code review (architecture · tests · performance) and have been shipping the fixes as small PRs. **Five PRs merged this session; one open (#13).** Test suite went **78 → 100 green** (net8.0 + net10.0). The full prioritized plan lives in **`FIX-PLAN.md`** (repo root, git-ignored/untracked — read it first for detail).
+We're working the three-specialist review fix plan (**`FIX-PLAN.md`**, repo root — read it for per-item file:line detail). This session cleared the top of the plan and opened the performance track. **`master` is clean at `ef25761`, no open PRs.** Suite is **green — 51 tests on net10.0** locally (CI runs net8.0 + net10.0).
 
-The repo is still **pre-stable** (no `v*` tag; only auto-alphas published), so **breaking changes are free** — do the breaking cleanup now.
+Still **pre-stable** (no `v*` tag; only auto-alphas published), so breaking changes remain free — keep doing breaking cleanup now.
 
 ## Current state
-- Branch to be on next session: **`master`** (@ `9782f4b`, PR #12). Once #13 merges, `git checkout master && git pull`.
-- **Open PR #13** — `chore/rename-solution-to-simplesettings` → renames `src/ExistAll.SimpleConfig.slnx` to `src/SimpleSettings.slnx` + updates the 11 workflow references. Merge it, then continue.
-- Working tree carries two uncommitted, intentional-leftover edits (NOT part of any PR): `SESSION-HANDOFF.md` (this file) and `src/SimpleSettings.slnx` (a Solution-Items entry adding SESSION-HANDOFF.md — from the IDE). `FIX-PLAN.md` is untracked. Leave them unless you decide to commit.
-- Orphaned remote branches from #8–#12 are still on origin (merged); safe to delete anytime.
+- On **`master`** @ `ef25761` (PR #17). Clean tree, no open PRs. Next work branches off `master`.
+- Orphaned merged remote branches (from #8–#17) can be pruned anytime; deleting remote branches needs the `guy-lud` push identity.
 
-## What shipped this session
-Merged to `master` (all non-breaking except #11/#13 which are pre-stable breaking):
-- **#8** — five correctness bugfixes + regression tests: register `EnumTypeConverter` (enum-from-string was throwing); `InvariantCulture` in `DefaultTypeConverter` (locale parse bug); `BindingContext.PropertyType` = property's type not declaring interface; guard the options validator when `AttributeType` is null; fix two broken `Resources` message templates.
-- **#10** — `BindingContext.PropertyType` regression test (re-landed onto master; see stranding note below).
-- **#11** — fix the `ExistsForAll` → `ExistForAll` namespace typo in the Binders package (one file was a letter off).
-- **#12** — DI integration tests for `AddSimpleSettings` (headline feature, previously 0 coverage); wired the test project to `Extensions.GenericHost` + added `Microsoft.Extensions.DependencyInjection` via CPM.
-
-Open: **#13** (solution rename, above).
+## What shipped (recent → older)
+- **#17 — P1 + C3.** `ISettingsProvider.GetSettings` used to re-bind a fresh instance on every call while DI registered startup-built singletons (the C3 divergence). The provider now serves the startup-built `ISettingsCollection` — the *same* instance as the DI singleton — falling back to a build only for never-scanned types. **C3 contract = cache in the provider only** (Core's public `SettingsBuilder.GetSettings` unchanged; no reload — settings are immutable snapshots). + regression test (both paths `ReferenceEquals`).
+- **#16 — P0 benchmark harness.** Rebuilt the benchmark into a `[MemoryDiagnoser]` BenchmarkDotNet harness: `ScanBenchmark.ColdScan`; `ResolveBenchmark` (`[Params]` 1/10/50 · `ColdBuild` / `WarmResolve_Provider` / `WarmResolve_DiSingleton`); `ShapeBenchmark` (typed / array / deep-hierarchy). Run: `dotnet run -c Release --project src/performance/ExistForAll.SimpleSettings.Benchmark` (fast smoke: append `-- --job dry`). Baseline numbers intentionally NOT committed (machine-specific).
+- **#15 — A2 naming consolidation.** All code/projects now spell the org **`ExistForAll`** (was a mix of `ExistAll` / `ExistsForAll`). Renamed the Binders folder (csproj + package id unchanged), the benchmark project, `Company` / `PackageTags`, and the README brand line.
+- **#13 — solution file** `ExistAll.SimpleConfig.slnx` → `SimpleSettings.slnx` (first half of A2); the workflows now reference it through a `SOLUTION` env var.
+- Earlier: #8 (five correctness bugfixes + tests), #10 (BindingContext test), #11 (D3 namespace typo), #12 (DI integration tests), #14 (fix plan + prior handoff).
 
 ## Key decisions & context (carry forward)
-- **Validations API (D1) — HELD, do NOT delete.** The whole `Validations/*` namespace + `SettingsPropertyAttribute.ValidatorType` is public but never invoked. Owner intends to **build the validation feature in the near future** — there is already an existing **`validate-settings`** branch on origin to reconcile with. Wire it into `ValuesPopulator` (run validators after binding, aggregate errors, throw typed exception).
-- **`EqualityCompererCreator` (D2) — HELD too** by the same logic (internal, dead, and has a latent invalid-IL bug at `EqualityCompererCreator.cs:38`). Delete only if the owner decides value-equality on generated types isn't wanted.
-- **Pre-stable window:** no `v*` stable tag exists (the `version-*` tags are the dead legacy `ExistAll.SimpleConfig` package). Breaking API changes are free until the first `v2.0.0-beta`.
-- **Stacked-PR lesson:** #9 (a BindingContext test) was stacked on #8's branch and merged *there*; because #8 was squash-merged to master separately, #9 never reached master. Re-landed as #10. **Takeaway:** don't stack PRs on a branch that will be squash-merged — branch off master, or merge the base first.
+- **C3 resolved — option 2 (provider-level cache).** Core builder unchanged; no runtime reload. A reload / `IOptionsMonitor`-style path (change tokens) is the future "option 3" feature if it's ever wanted.
+- **Validations (D1) — HELD, do NOT delete.** The public `Validations/*` namespace + `SettingsPropertyAttribute.ValidatorType` are dead but intended for an upcoming feature; reconcile with the existing **`validate-settings`** branch on origin. Wire into `ValuesPopulator` (run validators after binding, aggregate errors, throw typed).
+- **`EqualityCompererCreator` (D2) — HELD** (internal, dead, latent invalid-IL bug at `EqualityCompererCreator.cs:38`). Delete only if value-equality on generated types is unwanted.
+- **Pre-stable window:** no `v*` stable tag (the `version-*` tags are the dead legacy `ExistAll.SimpleConfig` package). Breaking changes free until the first `v2.0.0-beta`.
 
 ## Next priorities (ranked — detail in FIX-PLAN.md)
-1. **Merge #13**, then optionally finish the `SimpleConfig` naming (A2): rename the Binders *folder* `Core/ExistAll.SimpleConfig.Extensions.Binders/` (updates the `.slnx` project path + test csproj ref), then `docs/*`, `README.md`, `PackageTags`, a benchmark comment.
-2. **Validations feature (D1)** — owner-driven; reconcile with the `validate-settings` branch.
-3. **Performance (Phase 5):** P0 (benchmark harness — `[MemoryDiagnoser]` + phased scenarios) → **P1 (cache the `ISettingsProvider` instance)** which also fixes the C3 provider-vs-singleton divergence → P2 (memoize `ExtractTypeProperties` + fix O(n²) dedup) → P3 (compiled setter plan).
-4. **More engine tests:** T4 `ValuesPopulator` (precedence + exception wrappers), T5 `TypeConverter` (null/nullable/empty-enumerable/attribute), T6 converters, T7 generator caching + concurrency stress.
-5. **Architecture calls:** A1 (AOT/trim `[RequiresDynamicCode]`/`[RequiresUnreferencedCode]` — HIGH, it's a `Reflection.Emit` lib on net8/net10), C1 (`List<T>`/`IList<T>` support), C2 (public `SimpleSettingsException` base), C3 (reload/`IOptionsMonitor` — pairs with P1), A3 (`Core.AspNet` exports no public type), A4 (float `Microsoft.Extensions.*` floor per-TFM), A5 (make `SettingsHolder` internal), A6 (command-line quoted-arg parsing).
+1. **P2** — memoize `TypePropertiesExtractor.ExtractTypeProperties` (shared `ConcurrentDictionary<Type, PropertyInfo[]>`) and replace its O(n²) dedup with a `HashSet<string>`. Sev High, Eff S, no decision; visible on the P0 harness. *(in progress this session)*
+2. **Rest of perf:** quick wins **Q1–Q5** (GetEnumerator `yield`, `OrdinalIgnoreCase` suffix match, env-binder fast path, generated-type cache, dead null-checks) → **P3** (cached compiled "settings plan" — biggest ceiling) → P4 (de-reflect array/enumerable converters) → P5 (resolve config section once per type).
+3. **Engine tests:** T4 `ValuesPopulator`, T5 `TypeConverter`, T6 converters, T7 generator caching + concurrency stress.
+4. **Architecture:** A1 (AOT/trim `[RequiresDynamicCode]`/`[RequiresUnreferencedCode]` — HIGH, it's a `Reflection.Emit` lib), C1 (`List<T>`/`IList<T>` support), C2 (public `SimpleSettingsException` base), A3 (`Core.AspNet` public type or drop the package), A4 (float `Microsoft.Extensions.*` floor per-TFM), A5 (make `SettingsHolder` internal), A6 (command-line quoted-arg parsing).
+5. **Docs debt (deferred from A2):** the `SimpleConfig` → `SimpleSettings` refresh — the `docs/*.md` tutorials and the README links still pointing at `existall/SimpleConfig`.
+6. **D1 validations feature** — owner-driven; reconcile the `validate-settings` branch.
 
 ## How releasing works (unchanged — durable)
-- **`ci.yml`** — on PRs to `master`: build + test (net8.0 + net10.0). **`release.yml`**:
-  - push to `master` → auto-publishes a MinVer height-based `-alpha` prerelease to nuget.org.
-  - manual **Release** (`workflow_dispatch`) with `channel` (beta/rc/stable) + `bump` (patch/minor/major) → computes the next version, tags `v*`, publishes, creates a GitHub Release. `dry_run: true` previews.
-- **Versioning = MinVer**, tag prefix `v`, baseline **2.0.0**. Keyless publish via NuGet Trusted Publishing (OIDC). First real release: Actions → Release → `channel: beta` (→ `v2.0.0-beta.1`); use `dry_run` first.
-- Both workflows invoke the solution by name — now **`SimpleSettings.slnx`** (via #13).
+- **`ci.yml`** — on PRs to `master`: build + test (net8.0 + net10.0). **`release.yml`**: push to `master` → auto-publishes a MinVer height-based `-alpha` to nuget.org; manual **Release** (`workflow_dispatch`, `channel` beta/rc/stable + `bump` patch/minor/major) computes the next version, tags `v*`, publishes, creates a GitHub Release (`dry_run: true` previews).
+- **Versioning = MinVer**, tag prefix `v`, baseline **2.0.0**, keyless publish via NuGet Trusted Publishing (OIDC). First real release: Actions → Release → `channel: beta` (→ `v2.0.0-beta.1`); use `dry_run` first.
+- Both workflows invoke the solution through the `SOLUTION` env var (**`SimpleSettings.slnx`**).
 
 ## Gotchas a new session MUST know
-- **Pushing / PRs:** the active `git`/`gh` identity is **read-only** on this repo; a separate account has push access. The exact recipe (SSH alias, account names, `gh` account-switch flow) lives in the assistant's **private project memory** (`simplesettings-push-access`) — deliberately kept out of this public file.
-- **Run `dotnet` from `src/`** (global.json opts into Microsoft.Testing.Platform for TUnit). Only the net10 runtime is installed locally → net8 tests are build-only locally; CI runs both. Do NOT prefix `cd <repo-root>` before `dotnet` — the solution lives in `src/`.
-- **`FIX-PLAN.md`** (repo root, untracked) is the full, prioritized fix plan with per-item file:line detail. It is NOT auto-injected — open it explicitly.
+- **Pushing / PRs:** the active `git`/`gh` identity (`guy-frontegg`) is **read-only** on this repo; push/PR/merge via the **`guy-lud`** account — SSH alias `github-guy-lud` for `git push`, `gh auth switch --user guy-lud` for `gh` writes (switch back to `guy-frontegg` after). Full recipe in the assistant's private project memory (`simplesettings-push-access`).
+- **Run `dotnet` from `src/`** (global.json opts into Microsoft.Testing.Platform for TUnit). Only the net10 runtime is installed locally → net8 is **build-only** locally; CI runs both. Do NOT prefix `cd <repo-root>` before `dotnet`.
+- **`FIX-PLAN.md`** (repo root) is the full, prioritized plan with per-item file:line detail — open it explicitly; it is not auto-injected.
 - Commits/PRs here **omit** the Co-Authored-By / Generated-with trailer (project preference).


### PR DESCRIPTION
Brings the two tracking docs up to date with the work merged this cycle (#13, #15, #16, #17) so the next session bootstraps from an accurate picture.

- **`SESSION-HANDOFF.md`** — rewritten: current state (master @ `ef25761`, no open PRs), what shipped (#13 solution rename, #15 A2 naming→ExistForAll, #16 P0 benchmark harness, #17 P1 provider cache + C3), the **C3 decision** (option 2 — cache in the provider only; Core builder unchanged; no reload), and the ranked next steps (P2 → quick wins/P3 → tests → architecture → docs debt → D1).
- **`FIX-PLAN.md`** — updated the "Progress" banner and recorded the C3 decision.

Reviewed in an isolated git worktree by a second agent that verified every factual claim against git / the merged PRs / the merged source (and ran the suite), and caught a units bug in my first draft: the banner mixed a both-TFM start (`78`) with a per-TFM end (`51`), reading as a shrink — corrected to **`78 → 102 green (51 per TFM)`**.

Docs-only; no code changes.
