### PR TITLE
Refresh the docs/ tutorials for the SimpleSettings rename and current API

### DIFF
--- a/docs/Build Config Interface.md
+++ b/docs/Build Config Interface.md
@@ -1,56 +1,53 @@
-﻿# Build Config Interface
+# Build a Settings Interface
 
-To Create a Config Interface you only need to build an interface with the property you need like so.
+To create a Settings Interface you only need to build an interface with the property you need like so.
 
 ````C#
 public interface ISomeInterface
 {
     string SomeProperty { get; set; }
-    
-    [DefaultValue(1,2,3,4,5)]
+
+    [SettingsProperty(DefaultValue = new[] { 1, 2, 3, 4, 5 })]
     int[] ArrayOfIds { get; set; }
 }
-
 ````
 
-Now we need to mark the interface that this is a Config Interface, SimpleConfig let you do this in three ways:  
-1. An Interface.
+Now we need to mark the interface that this is a Settings Interface, SimpleSettings let you do this in three ways:
+1. A base interface.
 ````C#
-public interface ISomeInterface : IConfigSection
+public interface ISomeInterface : ISettingsSection
 {
     string SomeProperty { get; set; }
-    
-    [DefaultValue(1,2,3,4,5)]
+
+    [SettingsProperty(DefaultValue = new[] { 1, 2, 3, 4, 5 })]
     int[] ArrayOfIds { get; set; }
 }
-
-`````
+````
 2. An Attribute.
 ````C#
-[ConfigSection]
+[SettingsSection]
 public interface ISomeInterface
 {
     string SomeProperty { get; set; }
-    
-    [DefaultValue(1,2,3,4,5)]
+
+    [SettingsProperty(DefaultValue = new[] { 1, 2, 3, 4, 5 })]
     int[] ArrayOfIds { get; set; }
 }
 ````
 
-3. Interface name Suffix.  
-By default SimpleConfig scan for interfaces with name ending with Config and adds it to the ConfigCollection. ( The suffix option can be change using `ConfigOptions` to know more look at the [Extend section]())
+3. Interface name Suffix.
+By default SimpleSettings scans for interfaces with a name ending with `Settings` and adds it to the collection. ( The suffix option can be changed using `SettingsOptions`, to know more look at the [Extend section](https://github.com/existall/SimpleSettings/blob/master/docs/Extend%20Simple%20Config.md) )
 
 ````C#
-[ConfigSection]
-public interface ISomeInterfaceConfig
+public interface ISomeInterfaceSettings
 {
     string SomeProperty { get; set; }
-    
-    [DefaultValue(1,2,3,4,5)]
+
+    [SettingsProperty(DefaultValue = new[] { 1, 2, 3, 4, 5 })]
     int[] ArrayOfIds { get; set; }
 }
 ````
 
-## SimpleConfig is built to make your application independent Frameworks so every indication of config interface can be changed using `ConfigOptions`
+## SimpleSettings is built to keep your application independent from frameworks so every indication of a settings interface can be changed using `SettingsOptions`
 
-In the next page we will explain about [DefaultValue Attribute](https://github.com/existall/SimpleConfig/blob/master/docs/Default%20Values.md)
+In the next page we will explain about the [SettingsProperty Attribute](https://github.com/existall/SimpleSettings/blob/master/docs/Default%20Values.md)

--- a/docs/Build a SectionBinder.md
+++ b/docs/Build a SectionBinder.md
@@ -1,36 +1,60 @@
-﻿# Build a SectionBinder
-SectionBinders are SimpleConfig way to pass values into properties not only from `DefaultValue` but from other data sources.
+# Build a SectionBinder
+SectionBinders are SimpleSettings' way to pass values into properties not only from the `SettingsProperty` default value but from other data sources.
 
-Out of the box SimpleConfig provides two Binders:  
-1. InMemoryCollection
-2. ConfigurationBinder - which is a binder that extracts values from .Net Core `IConfiguration`.
+Out of the box SimpleSettings provides these Binders:
+1. `InMemoryCollection` - lives in the core package.
+2. `ConfigurationBinder` - extracts values from .NET `IConfiguration`.
+3. `EnvironmentVariableBinder` - reads values from environment variables.
+4. A command line binder - reads values from command line arguments.
 
-
-### Building a SectionProvider
-
-SectionProvider is an implementation of `ISectionBinder` interface.
-
-SimpleConfig invokes the next method
-
-`bool TryGetValue(ConfigBindingContext bindingContext, out string value);`
-
-- SimpleConfig ask you to tell him rather or not you successfully get the value from the data source by returning a true or false result.
-- The Binder `TryGetValue` has an `out` parameter of `string` which SimpleConfig will try to convert and set into the property.
-- TryGetValue provide a context with the current Section, Current Key and the current Value up till now.
+The last three live in the `ExistForAll.SimpleSettings.Binders` package.
 
 
-### Section 
-The section name the context provides is the name of the interface with some manipulation, for example the interface `ISomeInterface` will be provided by the context as `SomeInterface`. SimpleConfig removes the `I`.  
-#### this is configurable via `ConfigOptions` and can be view on the [Extended section]()
+### Building a SectionBinder
+
+A SectionBinder is an implementation of the `ISectionBinder` interface.
+
+SimpleSettings invokes the next method
+
+`void BindPropertySettings(BindingContext context);`
+
+- The context provides the current `Section`, `Key` and the current value up till now (`CurrentValue`).
+- When you resolve a value from your data source, call `context.SetNewValue(value)` and SimpleSettings will try to convert it and set it into the property.
+- If you have nothing to contribute, simply don't call `SetNewValue` and the current value is preserved for the next binder.
+
+````C#
+public class MySectionBinder : ISectionBinder
+{
+    public void BindPropertySettings(BindingContext context)
+    {
+        if (TryLookup(context.Section, context.Key, out var value))
+            context.SetNewValue(value);
+    }
+}
+````
+
+### Section
+The section name the context provides is the name of the interface with some manipulation, for example the interface `ISomeInterface` will be provided by the context as `SomeInterface`. SimpleSettings removes the leading `I`.
+#### this is configurable via `SettingsOptions` (or per interface with `[SettingsSection("name")]`) and can be viewed on the [Extend section](https://github.com/existall/SimpleSettings/blob/master/docs/Extend%20Simple%20Config.md)
 
 ### Key
-The Key name the context provides is the property name as is, for example the interface `ISomeInterface.SomeProperty` will be provided as `SomeProperty`.
+The Key name the context provides is the property name as is, for example the interface `ISomeInterface.SomeProperty` will be provided as `SomeProperty`. You can override it per property with `[SettingsProperty(Name = "...")]`.
 
 ### Current Value
 
-Since Order between the binders is important the context will provide the current value as `string` that the former binders has set already.
+Since order between the binders is important the context will provide the current value (as `object?`) that the former binders have set already, starting from the property's default value.
 
-In the next page we will learn how to [Extend](https://github.com/existall/SimpleConfig/blob/master/docs/Extend%20Simple%20Config.md) SimpleConfig and future features.
+### In-memory values
 
+The `InMemoryCollection` binder is the simplest way to feed values. Create a collection, add your `section`/`key`/`value` entries, and wire it up with `AddInMemoryCollection`:
 
+````C#
+var collection = new InMemoryCollection();
+collection.Add("SomeInterface", "SomeProperty", "value");
 
+var settings = SettingsBuilder
+    .CreateBuilder(factory => factory.AddInMemoryCollection(collection))
+    .GetSettings<ISomeInterface>();
+````
+
+In the next page we will learn how to [Extend](https://github.com/existall/SimpleSettings/blob/master/docs/Extend%20Simple%20Config.md) SimpleSettings and future features.

--- a/docs/Default Values.md
+++ b/docs/Default Values.md
@@ -1,34 +1,37 @@
-﻿# Default Values
+# Default Values
 
-Default values allow you to instantiate properties with default values on run time, if no value has been set by the binders SimpleConfig will check to see if there is a default value attribute with value and set it to the property.
+Default values allow you to instantiate properties with default values on run time, if no value has been set by the binders SimpleSettings will check to see if there is a `SettingsProperty` attribute with a `DefaultValue` and set it to the property.
 
-### Disclaimer: at this time your application is coupled with the DefaultValue attribute, yet SimpleConfig will check for inheritance thus you can inherit from `DefaultValueAttribute` and decouple your application this way.
+### Disclaimer: at this time your application is coupled with the `SettingsProperty` attribute, yet SimpleSettings will check for inheritance thus you can inherit from `SettingsPropertyAttribute` and decouple your application this way.
 
-### Supported Types and values 
-DefaultValue allows you to pass one or more values, for example;
+### Supported Types and values
+`DefaultValue` accepts any value (including arrays) that can be converted to the property type, for example;
 
 ````C#
 
-[DefaultValue("Moby Dick")]
+[SettingsProperty(DefaultValue = "Moby Dick")]
 public string Name { get; set; }
 
-[DefaultValue(1,2,3,8)]
-pubic int[] Ids { get; set; }
+[SettingsProperty(DefaultValue = new[] { 1, 2, 3, 8 })]
+public int[] Ids { get; set; }
 ````
 
-SimpleConfig checks what is the return property type and try convert it into the correct value.
+SimpleSettings checks what is the return property type and tries to convert it into the correct value.
 
-DefaultValue also supports : `Enum`, `DateTime`, `Uri`, `Array` and `Nullable`
+`DefaultValue` also supports : `Enum`, `DateTime`, `Uri`, arrays and `IEnumerable<T>` collections.
 
 
-Since many developers use different `DateTime` formats, SimpleConfig allows you to change the Parser format. The default parser format is `"yyyy-MM-dd` yet you can change it by placing a different format in `ConfigOptions.DateTimeFormat`.
+Since many developers use different `DateTime` formats, SimpleSettings allows you to change the parser format. The default parser format is `"yyyy-MM-dd"` yet you can change it by placing a different format in `SettingsOptions.DateTimeFormat`.
 
 ````C#
-[DefaultValue("2012-09-19")]
-pubic DateTime StartTime { get; set; }
+[SettingsProperty(DefaultValue = "2012-09-19")]
+public DateTime StartTime { get; set; }
 ````
 
-### More Attribute supported from version 2
-1. SimpleConfig now support 
+### More `SettingsProperty` options
+The `SettingsProperty` attribute exposes a few more members beyond `DefaultValue`:
+1. `Name` - override the key the binders look up for this property (defaults to the property name).
+2. `ConverterType` - use a specific `ISettingsTypeConverter` for this property.
+3. `AllowEmpty` - when set to `false`, binding throws if no value was resolved for the property (defaults to `true`).
 
-In the next page we will discuss how to create [SectionBinder]()
+In the next page we will discuss how to create a [SectionBinder](https://github.com/existall/SimpleSettings/blob/master/docs/Build%20a%20SectionBinder.md)

--- a/docs/Extend Simple Config.md
+++ b/docs/Extend Simple Config.md
@@ -1,51 +1,77 @@
-﻿# Extend Simple Config
-## ConfigOptions
-Let's look at `ConfigOptions` which is the way you may change SimpleConfig default behavior.
+# Extend SimpleSettings
+## SettingsOptions
+Let's look at `SettingsOptions` which is the way you may change SimpleSettings default behavior.
 
 ````C#
-public class ConfigOptions
+public class SettingsOptions
 {
-		public Type AttributeType { get; set; } = typeof(ConfigSectionAttribute);
-		public Type InterfaceBase { get; set; } = typeof(IConfigSection);
-		public string ConfigSuffix { get; set; } = "Config";
-		public string ArraySplitDelimiter { get; set; } = ",";
-		public string DateTimeFormat { get; set; } = "yyyy-MM-dd";
-		public Func<string, string> SectionNameFormater => (interfaceName) => interfaceName.Trim('I');
+    public Type AttributeType { get; set; } = typeof(SettingsSectionAttribute);
+    public Type InterfaceBase { get; set; } = typeof(ISettingsSection);
+    public string SettingsSuffix { get; set; } = "Settings";
+    public string ArraySplitDelimiter { get; set; } = ",";
+    public string DateTimeFormat { get; set; } = "yyyy-MM-dd";
+    public Func<Type, string> SectionNameFormatter { get; set; } = (interfaceType) => interfaceType.GetNormalizeInterfaceName();
 }
 ````
 
-## Decoupling SimpleConfig
-For good practice you always want your application to not be dependent on Frameworks such as SimpleConfig, except for the bootstrapping process (CompositionRoot) all of the data object, services and logic should be your own. This can be achieved using abstractions. SimpleConfig let you use your own types as indications of config interfaces.
+You don't set these properties directly; instead the builder factory exposes `SetupOptions` and a set of `Set*` helpers that mutate the options for you.
+
+````C#
+SettingsBuilder.CreateBuilder(factory =>
+{
+    factory.SetSettingsSuffix("Settings");
+    factory.SetAttributeType(typeof(MyAttribute));
+    factory.SetInterfaceBase(typeof(IMyMarker));
+    factory.SetSectionNameFormatter(type => type.Name);
+});
+````
+
+## Decoupling SimpleSettings
+For good practice you always want your application to not be dependent on Frameworks such as SimpleSettings, except for the bootstrapping process (CompositionRoot) all of the data object, services and logic should be your own. This can be achieved using abstractions. SimpleSettings let you use your own types as indications of settings interfaces.
 
 ### AttributeType
-As mentioned in [Building the collection]() SimpleConfig scans all the assemblies provided in the `Build` method, any Types with `ConfigSectionAttribute` will be add to the ConfigCollection. By replacing the Type with your own, SimpleConfig will scan for your Attribute.
+SimpleSettings scans all the assemblies provided to `ScanAssemblies`, any Types with `SettingsSectionAttribute` will be added to the collection. By replacing the Type with your own (via `SetAttributeType`), SimpleSettings will scan for your Attribute.
 
 ### InterfaceBase
-Same as `AttributeType` SimpleConfig searches for `IConfigSection` interface as indication of config interface. By replacing the interface Type with your own, SimpleConfig will scan for your interface.
+Same as `AttributeType`, SimpleSettings searches for the `ISettingsSection` interface as indication of a settings interface. By replacing the interface Type with your own (via `SetInterfaceBase`), SimpleSettings will scan for your interface.
 
-### ConfigSuffix
-Same as `AttributeType` and `ConfigSectionAttribute` SimpleConfig searches for interfaces with names ending with the `Config` suffix, you can provide any suffix you want.
+### SettingsSuffix
+Same as `AttributeType` and `SettingsSectionAttribute`, SimpleSettings searches for interfaces with names ending with the `Settings` suffix, you can provide any suffix you want via `SetSettingsSuffix`.
 
-#### although SimpleConfig provides three ways as config interface indications that does not mean you have to use all three, simply choose one -> "KISS".
+#### although SimpleSettings provides three ways as settings interface indications that does not mean you have to use all three, simply choose one -> "KISS".
 
 ## Type Converter Options
 
-### ArraySplitDelimiter 
-SimpleConfig tries to convert the binders string value into the property type, when the type is an array SimpleConfig needs to know with what to split the values. By default SimpleConfig uses `','` but I love giving you the choice to decide for yourself.
+### ArraySplitDelimiter
+SimpleSettings tries to convert the binders string value into the property type, when the type is an array SimpleSettings needs to know with what to split the values. By default SimpleSettings uses `','` (change it with `SetArraySplitDelimiter`) but I love giving you the choice to decide for yourself.
 
 ### DateTimeFormat
-When SimpleConfig tries to parse DateTime from string it uses this property as a format, you can change this to anything your application uses.
+When SimpleSettings tries to parse DateTime from string it uses this property as a format, you can change this to anything your application uses via `SetDateTimeFormat`.
+
+### Custom Type Converters
+SimpleSettings converts the resolved value into the property type using a chain of `ISettingsTypeConverter`. You can plug in your own by implementing the interface and registering it with `AddTypeConverter` (your converter is added first, so it wins over the built-in ones).
+
+````C#
+public class MyConverter : ISettingsTypeConverter
+{
+    public bool CanConvert(Type settingsType) => settingsType == typeof(MyType);
+
+    public object Convert(object value, Type settingsType) => MyType.Parse((string)value);
+}
+
+SettingsBuilder.CreateBuilder(factory => factory.AddTypeConverter(new MyConverter()));
+````
 
 ## Binders
 
-### SectionNameFormater
-SimpleConfig converts your config interface name into section name for the binders thus indicating and allowing you to know what to look for. As default SimpleConfig will trim the I from the interface name. If you like to replace this behavior simply provide a `Func<string,string>` of your own to do so.
+### SectionNameFormatter
+SimpleSettings converts your settings interface name into a section name for the binders thus indicating and allowing you to know what to look for. As default SimpleSettings will trim the leading `I` from the interface name. If you like to replace this behavior simply provide a `Func<Type, string>` of your own (via `SetSectionNameFormatter`) to do so.
 
 # Future Features
 
-I would like to continue and develop SimpleConfig as people will use it more and more thus helping and creating feature requests.
+I would like to continue and develop SimpleSettings as people will use it more and more thus helping and creating feature requests.
 
-Few ideas for future features are:  
+Few ideas for future features are:
 1. Diagnostics and reporting.
 2. Roslyn support for those who will want to use it. (I did some performance tests with Roslyn and it was not good).
 3. AOP.

--- a/docs/building_the_collection.md
+++ b/docs/building_the_collection.md
@@ -1,45 +1,47 @@
 # Building The Collection
-To build the `ConfigCollection` you must provide assemblies to which SimpleConfig scans them and get all the config interfaces.
+To build the settings collection you must provide the assemblies SimpleSettings scans in order to get all the settings interfaces.
 
-Thus SimpleConfig provides an AssemblyCollection for you to set all assemblies you want it to scan.
-We know that many applications uses different architectures so `AssemblyCollection` has one method
-
-
-## !!This feature will be removed in the next version, and will support only public interfaces!!
-`public void Add(IAssemblyHolder assemblyHolder)`
-
-`SimpleConfig` don't expect you to implement the `IAssemblyHolder` interface, it provide two extension methods.
-
-1. `AddExportedTypesAssembly` - Get the public config interfaces in the assemblies.
-2. `AddFullTypesAssembly` - Get all of the config interfaces in the assemblies, even the internal.
-
+You pass those assemblies to `ScanAssemblies`, which has an overload that accepts an `IEnumerable<Assembly>` and another that accepts one required assembly followed by any number of additional ones.
 
 ````C#
-var assemblyCollection = new AssemblyCollection()
-				.AddFullTypesAssembly(this.GetType().GetTypeInfo().Assembly)
-				.AddExportedTypesAssembly(typeof(SomeType).GetTypeInfo().Assembly);
+var settingsCollection = SettingsBuilder
+    .CreateBuilder()
+    .ScanAssemblies(typeof(Program).Assembly);
 ````
+
+SimpleSettings scans only the public (exported) interfaces in the assemblies you provide, so make sure the interfaces you want discovered are public.
 
 ## Options
 
-To the build method we need to pass `ConfigOptions`, this Options class allows you to replace some of SimpleConfig defaults. To better understand the ConfigOptions see the [Extend]() section.
+To configure SimpleSettings, use the `CreateBuilder` overload that gives you a builder factory. The factory exposes `SetupOptions` along with a set of `Set*` helpers that mutate `SettingsOptions`. To better understand the options see the [Extend](https://github.com/existall/SimpleSettings/blob/master/docs/Extend%20Simple%20Config.md) section.
 
-## Binders
-SimpleConfig can populate properties with values not only from `DefaultValue` attribute but from any `Binder` you can create.
-
-To add a Binder use the `Add` method on the `ConfigBuilder` like so.
 ````C#
-ConfigBuilder.Add(ISectionBinder sectionBinder);
+var settingsCollection = SettingsBuilder
+    .CreateBuilder(factory =>
+    {
+        factory.SetDateTimeFormat("yyyy-MM-dd");
+        factory.SetArraySplitDelimiter(";");
+    })
+    .ScanAssemblies(typeof(Program).Assembly);
 ````
 
-#### The order in which binders are added is important, the last binder will set the value into the property. If no value was set the deafult value will be set.
+## Binders
+SimpleSettings can populate properties with values not only from the `SettingsProperty` default value but from any `Binder` you can create.
 
-SimpleConfig provides two Binders out of the box, `ConfigurationBinder` which can extract values from Microsoft .Net Core `IConfiguraton` and `InMemoryCollection`. We are currently working on `SqlBinder`.
+To add a Binder use the `AddSectionBinder` method on the builder factory like so.
+````C#
+SettingsBuilder.CreateBuilder(factory =>
+{
+    factory.AddSectionBinder(sectionBinder);
+});
+````
 
-For more information about the Binders click on them.
-1. [ConfigurationBinder]()
-2. [InMemoryBinder]()
+#### The order in which binders are added is important, the last binder will set the value into the property. If no value was set the default value will be set.
 
-To create new Binders see [Extend section]()
+SimpleSettings provides several binders out of the box. `InMemoryCollection` lives in the core package and is added via `AddInMemoryCollection`. The `ExistForAll.SimpleSettings.Binders` package adds a `ConfigurationBinder` which can extract values from Microsoft .NET `IConfiguration` (via `AddConfiguration`), an `EnvironmentVariableBinder` (via `AddEnvironmentVariable`) and a command line binder (via `AddCommandLine` / `AddArguments`).
 
-To continue on to Config Interfaces click [here]()
+For more information about the Binders see the [Build a SectionBinder](https://github.com/existall/SimpleSettings/blob/master/docs/Build%20a%20SectionBinder.md) page.
+
+To create new Binders see the [Extend section](https://github.com/existall/SimpleSettings/blob/master/docs/Extend%20Simple%20Config.md).
+
+To continue on to Settings Interfaces click [here](https://github.com/existall/SimpleSettings/blob/master/docs/Build%20Config%20Interface.md).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,49 +1,97 @@
 Getting Started
 ===============
 
-SimpleConfig uses a `ConfigBuilder` in order to create a `ConfigCollection`. `ConfigCollection`holds a key value pair of `Type` and the generated implementation of the Config interface. Thus it can be easily registered to any IOC container of your liking.
+SimpleSettings (previously SimpleConfig) uses a `SettingsBuilder` in order to create your settings objects. `SettingsBuilder.ScanAssemblies` returns an `ISettingsCollection` that holds a key value pair of `Type` and the generated implementation of the settings interface. Thus it can be easily registered to any IOC container of your liking.
 
-`IConfigBuilder.Build` is the entry point to get all config files, the `Build` method accept a collection of Assemblies and ConfigOptions.
+## Installation
+SimpleSettings ships as a set of NuGet packages. The core package is all you need to get started:
 
 ````C#
-var assemblies = new[]{this.GetType().GetTypeInfo().Assembly};
-
-var configCollection = new ConfigBuilder().Build(assemblies, new ConfigOptions());
+dotnet add package ExistForAll.SimpleSettings
 ````
 
-the result is a new class `ConfigCollection` where you can iterate all of the implemintations of your config interfaces.
-
-## First Config Interface
-
-As written in the introduction SimpleConfig uses interfaces to pass values into services, thus we need to create our first interface.
+`SettingsBuilder.CreateBuilder` is the entry point. Once you have a builder, `ScanAssemblies` accepts one or more Assemblies and returns the collection of generated settings.
 
 ````C#
-[ConfigSection]
-public interface IEmailSenderConfig
+var assemblies = new[] { typeof(Program).Assembly };
 
-	[DefaultValue("SomeUrl")]
-	string EmailServiceUrl { get; set; }
-
-	[DefaultValue(3)]
-	int Retries { get; set; }
-}
+var settingsCollection = SettingsBuilder
+    .CreateBuilder()
+    .ScanAssemblies(assemblies);
 ````
 
-When `ConfigBuilder.Build` invoked, it will search all indication of a config interfaces and use `Emit` to create a concreate class at run time. (Unforunatly Roslyn was not fast enough). The `DefaultValue` Attribute will set the value into the property.
+the result is an `ISettingsCollection` where you can iterate all of the implementations of your settings interfaces.
 
-Now as the builder returns the `ConfigCollection` we can explicitly request the interface like so
+## First Settings Interface
 
-````C#
-IEmailSenderConfig config = configCollection.GetConfig<IEmailSenderConfig>();
-````
-and get the values we used as deafults or simply iterate over the items like so
+As written in the introduction SimpleSettings uses interfaces to pass values into services, thus we need to create our first interface.
 
 ````C#
-foreach (var configItem in configCollection)
+[SettingsSection]
+public interface IEmailSenderSettings
 {
-	Type interfaceType = configItem.Key;
-	object configImplemintation = configItem.Value;
+    [SettingsProperty(DefaultValue = "SomeUrl")]
+    string EmailServiceUrl { get; set; }
+
+    [SettingsProperty(DefaultValue = 3)]
+    int Retries { get; set; }
 }
 ````
 
-SimpleConfig is highly extendable and we will explain how to work with it on the next [page](https://github.com/existall/SimpleConfig/blob/master/docs/building_the_collection.md)
+When `ScanAssemblies` is invoked, it will search for every indication of a settings interface and use `Emit` to create a concrete class at run time. (Unfortunately Roslyn was not fast enough). The `SettingsProperty` attribute's `DefaultValue` will set the value into the property.
+
+Now as the builder returns the `ISettingsCollection` we can explicitly request the interface like so
+
+````C#
+IEmailSenderSettings settings = settingsCollection.GetSettings<IEmailSenderSettings>();
+````
+and get the values we used as defaults or simply iterate over the items like so
+
+````C#
+foreach (var settingsItem in settingsCollection)
+{
+    Type interfaceType = settingsItem.Key;
+    object settingsImplementation = settingsItem.Value;
+}
+````
+
+If you only need a single interface, you can skip the collection and ask the builder directly:
+
+````C#
+var settings = SettingsBuilder
+    .CreateBuilder()
+    .GetSettings<IEmailSenderSettings>();
+````
+
+## Using Dependency Injection
+
+Most applications will wire SimpleSettings into the .NET generic host. Add the `ExistForAll.SimpleSettings.Extensions.GenericHost` package and call `AddSimpleSettings`:
+
+````C#
+dotnet add package ExistForAll.SimpleSettings.Extensions.GenericHost
+````
+
+````C#
+services.AddSimpleSettings(o =>
+{
+    o.AddAssemblies(new[] { typeof(IEmailSenderSettings).Assembly });
+});
+````
+
+Every scanned interface is registered as a singleton, so you can inject it directly:
+
+````C#
+public class EmailSender
+{
+    public EmailSender(IEmailSenderSettings settings) { }
+}
+````
+
+You can also resolve settings through the registered `ISettingsProvider`:
+
+````C#
+var provider = serviceProvider.GetRequiredService<ISettingsProvider>();
+var settings = provider.GetSettings<IEmailSenderSettings>();
+````
+
+SimpleSettings is highly extendable and we will explain how to work with it on the next [page](https://github.com/existall/SimpleSettings/blob/master/docs/building_the_collection.md)


### PR DESCRIPTION
Refreshes all six tutorial docs under `docs/` so the samples compile against the **current public API** and reflect the `SimpleConfig` → `SimpleSettings` rename. Docs-only — no source touched.

## What changed
Every code sample was rewritten against the source (verified by reading it, not guessing). The load-bearing corrections:

- **Builder / collection / options:** `new ConfigBuilder().Build(assemblies, new ConfigOptions())` → `SettingsBuilder.CreateBuilder().ScanAssemblies(...)`; `ConfigCollection`/`GetConfig<T>` → `ISettingsCollection`/`GetSettings<T>`; `ConfigOptions` → `SettingsOptions`.
- **Attributes:** `[ConfigSection]`/`[DefaultValue(...)]` → `[SettingsSection]`/`[SettingsProperty(DefaultValue = ...)]`; array defaults use `new[] { ... }` instead of the old params style.
- **`ISectionBinder` contract:** `bool TryGetValue(ConfigBindingContext, out string)` → `void BindPropertySettings(BindingContext context)` with a worked example; `CurrentValue` corrected from `string` to `object?`.
- **DI:** added an installation section (`dotnet add package ExistForAll.SimpleSettings`) and a "Using Dependency Injection" section (`AddSimpleSettings`, injecting the interface directly, and `ISettingsProvider.GetSettings<T>()`).
- **In-memory binding** documented via the real public path `factory.AddInMemoryCollection(collection)` — `InMemoryBinder` is `internal` (test-only), so end users can't `new` it.
- **Removed dead/stale content:** the `AssemblyCollection`/`AddExportedTypesAssembly`/`IAssemblyHolder` API (already removed from the engine), the "feature will be removed" banner, and the "SqlBinder in progress" claim. Corrected the built-in binder inventory (InMemory in core; Configuration/Env/CommandLine in the `ExistForAll.SimpleSettings.Binders` package).
- **Links:** filled empty `]()` inter-doc links and pointed all GitHub links at `existall/SimpleSettings`.

## Verification
- `grep` sweep across `docs/`: no remaining `SimpleConfig` except one intentional "(previously SimpleConfig)" note; zero `ExistsForAll`/`ExistAll` misspellings; zero stale API symbols (`ConfigBuilder`, `ConfigCollection`, `ConfigOptions`, `[DefaultValue`, `GetConfig<`, `TryGetValue`, `AssemblyCollection`); no empty links.
- Branches from `ef25761` (#17); docs-only, so it merges cleanly on top of current `master`.
